### PR TITLE
Fixes #51 issue where message list is truncated

### DIFF
--- a/src/components/chat/MessageBox.js
+++ b/src/components/chat/MessageBox.js
@@ -83,6 +83,7 @@ class MessageBox extends Component {
       <div className="row message-box">
         <div className="col-md-12 message-list">
           <MessageList messages={messages} username={username} />
+          <div style={{clear: "both"}}></div>
         </div>
         <div style={{float: "left", clear: "both"}}
              ref={(el) => { this.messagesEnd = el }}>


### PR DESCRIPTION
Since the messages are individually floated, their parent container does
not expand to contain the list. So the bottom margin on the parent
container isn't being applied, hence the messages are truncated by the
fixed form at the bottom.

This change addresses the issue by putting in the old classic CSS hack
of a dummy element at the bottom, after all floated elements, which is
"clear:none;" which forces the parent container to expand around all
floated child elements. Not the ideal solution but quick and it works.