### PR TITLE
Fix #77: Responsive Header

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -3,6 +3,8 @@ import React, { Component } from 'react';
 const btoa = require('btoa');
 const atob = require('atob');
 
+import Header from './layout/Header';
+
 import AlertContainer from './general/AlertContainer';
 import ChatContainer from './chat/ChatContainer';
 
@@ -437,23 +439,28 @@ export default class App extends Component {
     console.log('Rendering...');
 
     return (
-      <main>
-        <AlertContainer
-          showAlert={showAlert}
-          message={alertMessage}
-          alertStyle={alertStyle}
-          onAlertDismiss={this.onAlertDismiss} />
+      <div className="encloser">
+        <Header
+          promptForUsername={this.promptForUsername} />
 
-        {showUsernameModal && <UsernameModal
-                                username={username || previousUsername}
-                                showModal={showUsernameModal}
-                                onSetUsername={this.onSetUsername}
-                                onCloseModal={this.onCloseUsernameModal} />}
-        <ChatContainer
-          messages={this.state.messages}
-          username={this.state.username}
-          onSendMessage={this.onSendMessage} />
-      </main>
+        <main>
+          <AlertContainer
+            showAlert={showAlert}
+            message={alertMessage}
+            alertStyle={alertStyle}
+            onAlertDismiss={this.onAlertDismiss} />
+
+          {showUsernameModal && <UsernameModal
+                                  username={username || previousUsername}
+                                  showModal={showUsernameModal}
+                                  onSetUsername={this.onSetUsername}
+                                  onCloseModal={this.onCloseUsernameModal} />}
+          <ChatContainer
+            messages={this.state.messages}
+            username={this.state.username}
+            onSendMessage={this.onSendMessage} />
+        </main>
+      </div>
     );
   }
 }

--- a/src/components/chat/ChatContainer.js
+++ b/src/components/chat/ChatContainer.js
@@ -6,12 +6,16 @@ import MessageForm from './MessageForm';
 class ChatContainer extends Component {
   render(){
     let { messages, username, onSendMessage } = this.props;
+
     return (
       <div className="content">
         <MessageBox
           messages={messages}
           username={username} />
-        <MessageForm onSendMessage={onSendMessage} />
+
+        <MessageForm
+          onSendMessage={onSendMessage} />
+
       </div>
     );
   }

--- a/src/components/chat/MessageBox.js
+++ b/src/components/chat/MessageBox.js
@@ -83,7 +83,6 @@ class MessageBox extends Component {
       <div className="message-box">
         <div className="message-list">
           <MessageList messages={messages} username={username} />
-          <div style={{clear: "both"}}></div>
         </div>
         <div style={{float: "left", clear: "both"}}
              ref={(el) => { this.messagesEnd = el }}>

--- a/src/components/chat/MessageForm.js
+++ b/src/components/chat/MessageForm.js
@@ -67,13 +67,15 @@ class MessageForm extends Component {
               <i className="fa fa-arrow-circle-right fa-2x"></i>
             </Button>
 
-            <textarea
-              className="form-control"
-              onChange={this.onMessageUpdate}
-              onKeyPress={this.onKeyPress}
-              name="message"
-              value={message}
-              placeholder="Enter message" required></textarea>
+            <div className="message">
+              <textarea
+                className="form-control"
+                onChange={this.onMessageUpdate}
+                onKeyPress={this.onKeyPress}
+                name="message"
+                value={message}
+                placeholder="Enter message" required></textarea>
+            </div>
 
           </div>
         </form>

--- a/src/components/chat/UserList.js
+++ b/src/components/chat/UserList.js
@@ -1,0 +1,35 @@
+import React, { Component } from 'react';
+
+export default class UserList extends Component {
+  constructor(props) {
+    super(props);
+
+    this.onClickUsersIcon = this.onClickUsersIcon.bind(this);
+  }
+
+  // TODO: if mobile make this do nothing
+  onClickUsersIcon(){
+  	$(this.refs.menuList).slideToggle();
+  }
+
+
+  render() {
+    return (
+      <div className="users-list">
+      	<div className="users-icon" onClick={this.onClickUsersIcon}>
+          <i className="fa fa-users fa-2x"></i>
+        </div>
+        <ul>
+          <li>
+            <i className="fa fa-circle"></i>
+            elimisteve
+          </li>
+          <li>
+            <i className="fa fa-minus-circle"></i>
+            EnlargedProstate
+          </li>
+        </ul>
+      </div>
+    );
+  }
+}

--- a/src/components/layout/Header.js
+++ b/src/components/layout/Header.js
@@ -1,0 +1,23 @@
+import React, { Component } from 'react';
+
+import UserList from '../chat/UserList';
+import Logo from './Logo';
+import Settings from './Settings';
+
+
+export default class Header extends Component {
+  constructor(props){
+    super(props);
+  }
+
+  render(){
+    return (
+      <header>
+        <Logo />
+        <UserList />
+        <Settings
+          promptForUsername={this.props.promptForUsername} />
+      </header>
+    )
+  }
+}

--- a/src/components/layout/Header.js
+++ b/src/components/layout/Header.js
@@ -13,10 +13,12 @@ export default class Header extends Component {
   render(){
     return (
       <header>
-        <Logo />
+        <div className="logo-container">
+          <Logo />
+          <Settings
+            promptForUsername={this.props.promptForUsername} />
+        </div>
         <UserList />
-        <Settings
-          promptForUsername={this.props.promptForUsername} />
       </header>
     )
   }

--- a/src/components/layout/Logo.js
+++ b/src/components/layout/Logo.js
@@ -1,0 +1,11 @@
+import React, { Component } from 'react';
+
+export default class Logo extends Component {
+  render() {
+    return (
+      <div className="logo">
+        LeapChat
+      </div>
+    );
+  }
+}

--- a/src/components/layout/Settings.js
+++ b/src/components/layout/Settings.js
@@ -1,0 +1,22 @@
+import React, { Component } from 'react';
+
+export default class Settings extends Component {
+  constructor(props) {
+    super(props);
+
+    this.onClickSettings = this.onClickSettings.bind(this);
+  }
+
+  // only one settings options for now
+  onClickSettings(){
+    this.props.promptForUsername();
+  }
+
+  render() {
+    return (
+      <div className="settings" onClick={this.onClickSettings}>
+        <i className="fa fa-cog fa-2x"></i>
+      </div>
+    );
+  }
+}

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -9,7 +9,6 @@ body {
 
 .encloser {
   display: flex;
-  min-height: 100vh;
   flex-direction: row; }
 
 @media (max-width: 768px) {
@@ -27,19 +26,20 @@ header {
   flex-direction: row;
   justify-content: space-between; }
   header .users-list {
-    order: -1; }
+    order: -1;
+    flex-grow: 1; }
     header .users-list .users-icon {
       cursor: pointer; }
     header .users-list ul {
       display: none; }
+  header .logo-container {
+    display: flex;
+    justify-content: space-between;
+    flex-grow: 1; }
   header .logo {
     text-align: center;
     font-size: 24px;
     font-weight: bold; }
-  header .menu-list {
-    display: none; }
-    header .menu-list i.fa {
-      margin-right: 5px; }
 
 @media (min-width: 768px) {
   header {
@@ -48,11 +48,16 @@ header {
     flex-direction: column;
     justify-content: start;
     height: 100vh; }
-    header .logo {
-      text-align: left;
-      order: -3; }
-    header .settings {
-      order: -2; } }
+    header .logo-container {
+      margin-bottom: 15px;
+      order: -1;
+      flex-grow: 0; }
+    header .users-list {
+      flex-grow: 0; }
+      header .users-list .users-icon {
+        display: none; }
+      header .users-list ul {
+        display: block; } }
 
 main {
   display: flex;
@@ -72,7 +77,6 @@ main {
         padding: 5px 10px;
         margin-bottom: 5px;
         width: 90%;
-        position: relative;
         word-wrap: break-word; }
         main .content .message-box ul li .username {
           display: block;
@@ -89,8 +93,6 @@ main {
         main .content .message-box ul li.chat-incoming {
           float: left;
           color: #333; }
-      main .content .message-box ul li:hover .delete-message {
-        visibility: visible; }
     main .content .message-list {
       padding: 0 15px; }
     main .content .message-form {

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -73,8 +73,7 @@ main {
         margin-bottom: 5px;
         width: 90%;
         position: relative;
-        word-wrap: break-word;
-        flex-grow: 1; }
+        word-wrap: break-word; }
         main .content .message-box ul li .username {
           display: block;
           font-weight: bold; }

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -7,68 +7,127 @@ body {
   font-size: 16px;
   font-family: 'Lato', sans-serif; }
 
-.container {
-  width: 100%; }
+.encloser {
+  display: flex;
+  min-height: 100vh;
+  flex-direction: row; }
+
+@media (max-width: 768px) {
+  .encloser {
+    flex-direction: column; } }
 
 ul {
   list-style: none; }
 
+header {
+  display: flex;
+  background-color: #1e202f;
+  color: #fff;
+  padding: 10px 10px 5px;
+  flex-direction: row;
+  justify-content: space-between; }
+  header .users-list {
+    order: -1; }
+    header .users-list .users-icon {
+      cursor: pointer; }
+    header .users-list ul {
+      display: none; }
+  header .logo {
+    text-align: center;
+    font-size: 24px;
+    font-weight: bold; }
+  header .menu-list {
+    display: none; }
+    header .menu-list i.fa {
+      margin-right: 5px; }
+
+@media (min-width: 768px) {
+  header {
+    flex: 1;
+    min-width: 300px;
+    flex-direction: column;
+    justify-content: start;
+    height: 100vh; }
+    header .logo {
+      text-align: left;
+      order: -3; }
+    header .settings {
+      order: -2; } }
+
+main {
+  display: flex;
+  flex-grow: 1; }
+  main .content {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1; }
+    main .content .message-box {
+      height: calc(100vh - 120px);
+      overflow-y: scroll;
+      padding-top: 5px; }
+      main .content .message-box ul li {
+        display: block;
+        border: solid 1px #eee;
+        border-radius: 10px;
+        padding: 5px 10px;
+        margin-bottom: 5px;
+        width: 90%;
+        position: relative;
+        word-wrap: break-word;
+        flex-grow: 1; }
+        main .content .message-box ul li .username {
+          display: block;
+          font-weight: bold; }
+        main .content .message-box ul li.chat-outgoing {
+          float: right;
+          color: white;
+          background-color: #827cd2; }
+          main .content .message-box ul li.chat-outgoing a {
+            text-decoration: underline;
+            color: white; }
+          main .content .message-box ul li.chat-outgoing a:hover {
+            color: #ddd; }
+        main .content .message-box ul li.chat-incoming {
+          float: left;
+          color: #333; }
+      main .content .message-box ul li:hover .delete-message {
+        visibility: visible; }
+    main .content .message-list {
+      padding: 0 15px; }
+    main .content .message-form {
+      padding: 5px;
+      background-color: white;
+      border-top: solid 1px #ccc;
+      margin-top: auto; }
+      main .content .message-form .message {
+        margin-right: 40px; }
+        main .content .message-form .message textarea {
+          /* this font-size disables zooming
+          on mobile safari, which breaks layout */
+          font-size: 16px; }
+      main .content .message-form button {
+        border: none;
+        padding: 5px;
+        float: right;
+        height: 54px;
+        vertical-align: bottom; }
+        main .content .message-form button i {
+          color: #1e202f; }
+
+@media (min-width: 768px) {
+  main {
+    flex: 5; }
+    main .content .message-box {
+      height: calc(100vh - 70px); } }
+
 .alert-container {
   position: fixed;
-  top: 0;
-  width: 100%;
+  top: 5px;
+  left: 10px;
+  right: 10px;
+  font-size: 12px;
   z-index: 10; }
-
-.message-box ul li {
-  display: block;
-  border: solid 1px #eee;
-  border-radius: 10px;
-  padding: 5px 10px;
-  margin-bottom: 5px;
-  width: 90%;
-  position: relative;
-  word-wrap: break-word; }
-  .message-box ul li .username {
-    display: block;
-    font-weight: bold; }
-  .message-box ul li.chat-outgoing {
-    float: right;
-    color: white;
-    background-color: #827cd2; }
-    .message-box ul li.chat-outgoing a {
-      text-decoration: underline;
-      color: white; }
-    .message-box ul li.chat-outgoing a:hover {
-      color: #ddd; }
-  .message-box ul li.chat-incoming {
-    float: left;
-    color: #333; }
-
-.message-box ul li:hover .delete-message {
-  visibility: visible; }
-
-.message-form {
-  position: fixed;
-  width: 100%;
-  left: 0px;
-  bottom: 0px;
-  padding: 5px;
-  background-color: white;
-  border-top: solid 1px #ccc; }
-  .message-form textarea {
-    /* this font-size disables zooming
-    on mobile safari, which breaks layout */
-    font-size: 16px;
-    width: calc(100% - 40px); }
-  .message-form button {
-    border: none;
-    padding: 5px;
-    float: right;
-    height: 54px;
-    vertical-align: bottom; }
-    .message-form button i {
-      color: #1e202f; }
-
-.message-list {
-  margin-bottom: 100px;
-  padding: 0 15px; }
+  .alert-container .alert {
+    padding: 5px 15px; }
+    .alert-container .alert.alert-dismissable .close {
+      right: auto; }

--- a/static/sass/_layout.scss
+++ b/static/sass/_layout.scss
@@ -5,99 +5,232 @@ html, body, ul {
 body {
   color: #222;
   font-size: 16px;
-  font-family: 'Lato', sans-serif; }
-
-// remove bootstrap's default gutters
-.container {
-  width: 100%;
+  font-family: 'Lato', sans-serif;
 }
+
+.encloser {
+  display: flex;
+  min-height: 100vh;
+  flex-direction: row;
+}
+
+@media (max-width: 768px) {
+  .encloser {
+    flex-direction: column;
+  }
+}
+
 
 ul {
   list-style: none;
 }
 
+// HEADER - mobile settings
+header {
+  display: flex;
+  background-color: $base-color;
+  color: #fff;
+  padding: 10px 10px 5px;
+  flex-direction: row;
+  justify-content: space-between;
+
+  .users-list {
+    order: -1;
+
+    .users-icon {
+      cursor: pointer;
+    }
+
+    ul {
+      display: none;
+    }
+  }
+
+  .logo {
+    text-align: center;
+    font-size: 24px;
+    font-weight: bold;
+  }
+
+  .settings {
+  }
+
+  .menu-list {
+    display: none;
+
+    i.fa {
+      margin-right: 5px;
+    }
+  }
+}
+
+
+// HEADER - desktop settings
+@media (min-width: 768px) {
+  header {
+    flex: 1;
+    min-width: 300px;
+    flex-direction: column;
+    justify-content: start;
+    height: 100vh;
+
+    .logo {
+      text-align: left;
+      order: -3;
+    }
+
+    .settings {
+      order: -2;
+    }
+
+    .user-list {
+
+    }
+  }
+}
+
+// MAIN - mobile settings
+main {
+
+  display: flex;
+  flex-grow: 1;
+
+  .content {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+
+    .message-box {
+        // scroll with flexbox needs revisiting
+        // for now, message box is viewport height
+        // less display height of message form
+        // + display height of header
+        height: calc(100vh - 120px);
+        overflow-y: scroll;
+        padding-top: 5px;
+
+      ul {
+        li {
+          display: block;
+          border: solid 1px #eee;
+          border-radius: 10px;
+          padding: 5px 10px;
+          margin-bottom: 5px;
+          width: 90%;
+          position: relative;
+          word-wrap: break-word;
+          flex-grow: 1;
+
+          .username {
+            display: block;
+            font-weight: bold;
+          }
+
+          &.chat-outgoing {
+            float: right;
+            color: white;
+            background-color: #827cd2;
+
+            a {
+              text-decoration: underline;
+              color: white;
+            }
+
+            a:hover {
+              color: #ddd;
+            }
+          }
+
+          &.chat-incoming {
+            float: left;
+            color: #333;
+
+          }
+        }
+
+        li:hover .delete-message {
+          visibility: visible;
+        }
+      }
+    }
+
+    .message-list {
+      padding: 0 15px;
+    }
+
+    .message-form {
+      padding: 5px;
+      background-color: white;
+      border-top: solid 1px #ccc;
+      margin-top: auto;
+
+      .message {
+        margin-right: 40px;
+
+        textarea {
+          /* this font-size disables zooming
+          on mobile safari, which breaks layout */
+          font-size: 16px;
+        }
+      }
+
+      button {
+        border: none;
+        padding: 5px;
+        float: right;
+        height: 54px;
+        vertical-align: bottom;
+
+        i {
+          color: #1e202f;
+        }
+      }
+    }
+
+  } // end .content
+
+} // end main
+
+// MAIN - desktop settings
+@media (min-width: 768px) {
+  main {
+    flex: 5;
+
+    .content {
+      .message-box{
+        // scroll with flexbox needs revisiting
+        // for now, message box is viewport height
+        // less display height of message form
+        height: calc(100vh - 70px);
+      }
+    }
+  }
+}
+
+// Alert styles, overrides default bootstrap
+// styles for positioning
 .alert-container {
   position: fixed;
-  top: 0;
-  width: 100%;
+  top: 5px;
+  left: 10px;
+  right: 10px;
+  font-size: 12px;
   z-index: 10;
-}
 
-.message-box {
-  ul {
-    li {
-      display: block;
-      border: solid 1px #eee;
-      border-radius: 10px;
-      padding: 5px 10px;
-      margin-bottom: 5px;
-      width: 90%;
-      position: relative;
-      word-wrap: break-word;
+  .alert {
+    padding: 5px 15px;
 
-      .username {
-        display: block;
-        font-weight: bold;
+    &.alert-dismissable {
+      .close {
+        right: auto;
       }
 
-      &.chat-outgoing {
-        float: right;
-        color: white;
-        background-color: #827cd2;
-
-        a {
-          text-decoration: underline;
-          color: white;
-        }
-
-        a:hover {
-          color: #ddd;
-        }
-      }
-
-      &.chat-incoming {
-        float: left;
-        color: #333;
-
-      }
-    }
-
-    li:hover .delete-message {
-      visibility: visible;
     }
   }
 }
 
-.message-form {
-  position: fixed;
-  width: 100%;
-  left: 0px;
-  bottom: 0px;
-  padding: 5px;
-  background-color: white;
-  border-top: solid 1px #ccc;
+// desktop
+@media (min-width: 768px) {
 
-  textarea {
-    /* this font-size disables zooming
-    on mobile safari, which breaks layout */
-    font-size: 16px;
-    width: calc(100% - 40px);
-  }
-
-  button {
-    border: none;
-    padding: 5px;
-    float: right;
-    height: 54px;
-    vertical-align: bottom;
-
-    i {
-      color: #1e202f;
-    }
-  }
 }
 
-.message-list {
-  margin-bottom: 100px;
-  padding: 0 15px;
-}

--- a/static/sass/_layout.scss
+++ b/static/sass/_layout.scss
@@ -119,7 +119,6 @@ main {
           width: 90%;
           position: relative;
           word-wrap: break-word;
-          flex-grow: 1;
 
           .username {
             display: block;

--- a/static/sass/_layout.scss
+++ b/static/sass/_layout.scss
@@ -10,7 +10,6 @@ body {
 
 .encloser {
   display: flex;
-  min-height: 100vh;
   flex-direction: row;
 }
 
@@ -19,7 +18,6 @@ body {
     flex-direction: column;
   }
 }
-
 
 ul {
   list-style: none;
@@ -36,6 +34,7 @@ header {
 
   .users-list {
     order: -1;
+    flex-grow: 1;
 
     .users-icon {
       cursor: pointer;
@@ -46,6 +45,12 @@ header {
     }
   }
 
+  .logo-container {
+    display: flex;
+    justify-content: space-between;
+    flex-grow: 1;
+  }
+
   .logo {
     text-align: center;
     font-size: 24px;
@@ -54,16 +59,7 @@ header {
 
   .settings {
   }
-
-  .menu-list {
-    display: none;
-
-    i.fa {
-      margin-right: 5px;
-    }
-  }
 }
-
 
 // HEADER - desktop settings
 @media (min-width: 768px) {
@@ -74,17 +70,22 @@ header {
     justify-content: start;
     height: 100vh;
 
-    .logo {
-      text-align: left;
-      order: -3;
+    .logo-container {
+      margin-bottom: 15px;
+      order: -1;
+      flex-grow: 0;
     }
 
-    .settings {
-      order: -2;
-    }
+    .users-list {
+      flex-grow: 0;
 
-    .user-list {
+      .users-icon {
+        display: none;
+      }
 
+      ul {
+        display: block;
+      }
     }
   }
 }
@@ -117,7 +118,6 @@ main {
           padding: 5px 10px;
           margin-bottom: 5px;
           width: 90%;
-          position: relative;
           word-wrap: break-word;
 
           .username {
@@ -145,10 +145,6 @@ main {
             color: #333;
 
           }
-        }
-
-        li:hover .delete-message {
-          visibility: visible;
         }
       }
     }
@@ -227,9 +223,3 @@ main {
     }
   }
 }
-
-// desktop
-@media (min-width: 768px) {
-
-}
-

--- a/static/sass/_variables.scss
+++ b/static/sass/_variables.scss
@@ -1,0 +1,1 @@
+$base-color: #1e202f;

--- a/static/sass/main.scss
+++ b/static/sass/main.scss
@@ -1,1 +1,2 @@
+@import 'variables';
 @import 'layout';


### PR DESCRIPTION
This change creates a responsive header for the app that lives at the
top of the site on mobile and as a sidebar for larger desktop screens.
It converts the primary elements in the layout to use the new flexbox
api. It also sets a fixed height on the messages container to allow for
scrolling when the message list overflows the height of the container,
which is less than flexy but will work for now. Elements are reordered
in the header between the mobile and desktop versions.