### PR TITLE
Fixed Mobile Header Responsiveness

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -14,6 +14,16 @@ body {
     max-width: 100vw;
     max-height: 100vh; } }
 
+@media (max-width: 767px) {
+  #page {
+    display: flex;
+    flex-direction: column;
+    max-height: 100vh; }
+    #page header {
+      flex: 1; }
+    #page main {
+      flex: 1; } }
+
 .encloser {
   display: flex;
   flex-direction: row; }

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -18,7 +18,8 @@ body {
   #page {
     display: flex;
     flex-direction: column;
-    max-height: 100vh; }
+    max-height: 100vh;
+    min-height: 100vh; }
     #page header {
       flex: 1; }
     #page main {

--- a/static/sass/_layout.scss
+++ b/static/sass/_layout.scss
@@ -8,12 +8,28 @@ body {
   font-family: 'Lato', sans-serif;
 }
 
+// Desktop - Max height * width
 @media (min-width: 768px) {
   #page {
     display: flex;
     flex-direction: row;
     max-width: 100vw;
     max-height: 100vh;
+  }
+}
+
+// Mobile
+@media (max-width: 767px) {
+  #page {
+    display: flex;
+    flex-direction: column;
+    max-height: 100vh;
+    header {
+      flex: 1;
+    }
+    main {
+      flex: 1;
+    }
   }
 }
 

--- a/static/sass/_layout.scss
+++ b/static/sass/_layout.scss
@@ -8,7 +8,7 @@ body {
   font-family: 'Lato', sans-serif;
 }
 
-// Desktop - Max height * width
+// Desktop - Max height & width
 @media (min-width: 768px) {
   #page {
     display: flex;
@@ -18,12 +18,13 @@ body {
   }
 }
 
-// Mobile
+// Mobile - Max & min height
 @media (max-width: 767px) {
   #page {
     display: flex;
     flex-direction: column;
     max-height: 100vh;
+    min-height: 100vh;
     header {
       flex: 1;
     }


### PR DESCRIPTION
Fixed Mobile Responsiveness

Default Mobile Header: 
![mobile header](https://user-images.githubusercontent.com/22757901/28750097-90a84798-7493-11e7-918c-1f55b69cbd26.png)

Users Displayed:
![mobile header - users displayed](https://user-images.githubusercontent.com/22757901/28750099-9e4654c6-7493-11e7-9330-627729e537ee.png)

App fills entire mobile dimensions,
Displayed Users doesn't break responsiveness now.

Existing Bug:  "LeapChat" Title shifts on Users displayed
I can work on fixing this bug next =P