### PR TITLE
Fixed Snytax Sytling, Fixed CSS Issues, & Component Refactor

### DIFF
--- a/src/components/chat/UserIcon.js
+++ b/src/components/chat/UserIcon.js
@@ -1,0 +1,16 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import FaGroup from 'react-icons/lib/fa/group';
+
+class UserIcon extends Component {
+
+  render() {
+    return (
+      <div className="users-icon">
+        <FaGroup size={30} onClick={this.props.toggleUserList} />
+      </div>
+    );
+  }
+}
+
+export default UserIcon;

--- a/src/components/chat/UserList.js
+++ b/src/components/chat/UserList.js
@@ -1,19 +1,21 @@
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import FaGroup from 'react-icons/lib/fa/group';
 import FaCircle from 'react-icons/lib/fa/circle';
 import FaMinusCircle from 'react-icons/lib/fa/minus-circle';
 import $ from 'jquery';
 
-export default class UserList extends Component {
+class UserList extends Component {
   constructor(props) {
     super(props);
-
-    this.onClickUsersIcon = this.onClickUsersIcon.bind(this);
   }
 
-  // TODO: if mobile make this do nothing
-  onClickUsersIcon() {
-    $(this.refs.menuList).slideToggle('fast');
+  styleUserList = () => {
+    if(this.props.displayUserList) {
+      return { display: 'block'};
+    } else {
+      return { display: 'none'};
+    }
   }
 
   sortByFrom(status1, status2) {
@@ -59,10 +61,7 @@ export default class UserList extends Component {
 
     return (
       <div className="users-list">
-        <div className="users-icon" onClick={this.onClickUsersIcon}>
-          <FaGroup size={30} />
-        </div>
-        <ul ref="menuList">
+        <ul style={this.styleUserList()}>
           {viewing.map(status => {
             return (
               <li key={status.key}>
@@ -96,7 +95,8 @@ export default class UserList extends Component {
 }
 
 const styleDots = {
-  marginRight: '.2em'
+  marginRight: '.2em',
+  marginTop: '.2em'
 }
 
 const styleViewing = Object.assign(
@@ -113,3 +113,5 @@ const styleOffline = Object.assign(
   { color: 'gray' },
   styleDots
 )
+
+export default UserList;

--- a/src/components/layout/Header.js
+++ b/src/components/layout/Header.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-
+import UserIcon from '../chat/UserIcon';
 import UserList from '../chat/UserList';
 import Logo from './Logo';
 import Settings from './Settings';
@@ -8,6 +8,12 @@ import Info from './Info';
 export default class Header extends Component {
   constructor(props){
     super(props);
+
+    this.state = { displayUserList: false };
+  }
+
+  toggleUserList = () => {
+    this.setState({ displayUserList: !this.state.displayUserList });
   }
 
   render(){
@@ -21,8 +27,10 @@ export default class Header extends Component {
           <Settings
             promptForUsername={this.props.promptForUsername} />
         </div>
+        <UserIcon toggleUserList={this.toggleUserList} />
         <UserList
-          statuses={this.props.statuses} />
+          statuses={this.props.statuses}
+          displayUserList={this.state.displayUserList} />
       </header>
     )
   }

--- a/src/components/layout/Settings.js
+++ b/src/components/layout/Settings.js
@@ -15,8 +15,8 @@ export default class Settings extends Component {
 
   render() {
     return (
-      <div className="settings" onClick={this.onClickSettings}>
-        <FaCog size={30} />
+      <div className="settings" >
+        <FaCog size={30} onClick={this.onClickSettings} />
       </div>
     );
   }

--- a/src/components/modals/Username.js
+++ b/src/components/modals/Username.js
@@ -10,6 +10,8 @@ class UsernameModal extends Component {
   constructor() {
     super(...arguments);
 
+    this.state = { failMessage: '' };
+
     this.onUsernameKeyPress = this.onUsernameKeyPress.bind(this);
     this.onSetUsernameClick = this.onSetUsernameClick.bind(this);
     this.setRandomUsernameInForm = this.setRandomUsernameInForm.bind(this);
@@ -44,17 +46,20 @@ class UsernameModal extends Component {
 
   isUsernameValid(username) {
     if (!username || username.length === 0) {
+      this.setState({ failMessage: 'Must not be empty' });
       return false;
+    } else if (username.length > 45) {
+      this.setState({ failMessage: 'Length must not exceed 45' });
+      return false;
+    } else {
+      return true;
     }
-    return true;
   }
 
   onSetUsernameClick(e) {
     let username = this.getUsernameInputValue()
 
-    if (!this.isUsernameValid(username)) {
-      alert('Invalid username!');
-    } else {
+    if (this.isUsernameValid(username)) {
       this.props.onSetUsername(username);
     }
   }
@@ -62,6 +67,14 @@ class UsernameModal extends Component {
   setRandomUsernameInForm() {
     let randomUsername = generateRandomUsername();
     this.setUsernameInputValue(randomUsername);
+  }
+
+  displayFailAlert = () => {
+    if(!!this.state.failMessage) {
+      return { display: 'block' };
+    } else {
+      return { display: 'none' };
+    }
   }
 
   render() {
@@ -77,6 +90,10 @@ class UsernameModal extends Component {
             <div className="form-group">
               <input type="text" className="form-control" ref="username" defaultValue={username || previousUsername} placeholder="Enter username (e.g., trinity)" onKeyPress={this.onUsernameKeyPress} />
               <br />
+              <div className="alert alert-danger" role="alert" style={this.displayFailAlert()} >
+                <strong>Invalid Username: </strong>
+                {this.state.failMessage}
+              </div>
               <Button bsSize="xsmall" bsStyle="primary" onClick={this.setRandomUsernameInForm}>Generate Random Username</Button>
             </div>
           </Modal.Body>

--- a/src/static/sass/_layout.scss
+++ b/src/static/sass/_layout.scss
@@ -54,17 +54,26 @@ header {
   padding: 10px 10px 5px;
   flex-direction: row;
   justify-content: space-between;
+  flex-wrap: wrap;
 
-  .users-list {
+  .users-icon {
     order: -1;
     flex-grow: 1;
-
-    .users-icon {
+    svg {
       cursor: pointer;
     }
+  }
+
+  .users-list {
+    flex: 0 1 100%;
 
     ul {
       display: none;
+      li {
+        svg {
+          float: left;
+        }
+      }
     }
   }
 
@@ -110,16 +119,23 @@ header {
       float: left;
     }
 
+    .users-icon {
+      display: none;
+    }
 
     .users-list {
       flex-grow: 0;
-
-      .users-icon {
-        display: none;
-      }
+      flex: none;
 
       ul {
-        display: block;
+        display: block !important;
+        li {
+          word-wrap: break-word;
+          svg {
+            float: left;
+            margin-top: 0.2em;
+          }
+        }
       }
     }
   }
@@ -225,9 +241,7 @@ main {
         }
       }
     }
-
   } // end .content
-
 } // end main
 
 // MAIN - desktop settings
@@ -269,7 +283,6 @@ main {
       .close {
         right: auto;
       }
-
     }
   }
 }
@@ -283,5 +296,12 @@ main {
       vertical-align: top;
       cursor: pointer;
     }
+  }
+}
+
+// Cursor effect over Settings button
+.settings {
+  svg {
+    cursor: pointer;
   }
 }


### PR DESCRIPTION
* In-Modal Display of Username Validation Failure (removed alert)
* CSS Fix -  Desktop View: long usernames now wrap
* Mobile View: clicking UsersIcon no longer pushes LeapChat logo
* Component Refactor: Pulled UserIcon button out so that UserList can begin on new row (previously, UserIcon and UserList were in the same div)

Screenshots: 

Desktop: Long Usernames wrap
![screen shot 2017-08-11 at 9 03 35 pm](https://user-images.githubusercontent.com/22757901/29237761-12269dce-7eda-11e7-8bd8-8f12649ddd49.png)

Mobile: Display UserList action doesn't displace LeapChat logo
![screen shot 2017-08-11 at 9 04 19 pm](https://user-images.githubusercontent.com/22757901/29237763-198e6790-7eda-11e7-8c70-062394183693.png)

Removed Alert, Replaced with In-Modal Fail Message
![screen shot 2017-08-11 at 9 04 54 pm](https://user-images.githubusercontent.com/22757901/29237765-1e44f786-7eda-11e7-8994-2d585fecc037.png)

