### PR TITLE
Simple relative timestamp solution

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "babel-loader": "^7.1.1",
     "btoa": "^1.1.2",
     "copy-webpack-plugin": "^4.0.1",
+    "date-fns": "^2.0.0-alpha.2",
     "emoji-datasource-apple": "^3.0.0",
     "emoji-js": "^3.2.2",
     "emoji-mart": "^1.0.1",

--- a/src/components/chat/Message.js
+++ b/src/components/chat/Message.js
@@ -1,4 +1,6 @@
 import React, { Component } from 'react';
+import { format, formatRelative } from 'date-fns';
+
 import emoji from '../../utils/emoji_convertor';
 import md from '../../utils/link_attr_blank';
 
@@ -7,6 +9,9 @@ class Message extends Component {
     let { message, username } = this.props;
     let fromMe = message.from === username;
     let messageClass = fromMe ? 'chat-outgoing' : 'chat-incoming';
+    
+    let RFCDate = message.key.split('-')[0];
+    let date = formatRelative(Date.parse(RFCDate), new Date());
 
     let emojified = emoji.replace_colons(message.msg);
 
@@ -29,9 +34,13 @@ class Message extends Component {
     // Render escaped HTML/Markdown
     let linked = md.render(emojiMD);
 
+
     return (
       <li className={'chat-message ' + messageClass} key={message.key}>
-        <span className="username">{message.from}</span>
+        <div className="message-header">
+          <span className="username">{message.from}</span>
+          <span className="message-timestamp">{date}</span>
+        </div>
         <div dangerouslySetInnerHTML={{__html: linked}}>
         </div>
       </li>

--- a/src/components/chat/Message.js
+++ b/src/components/chat/Message.js
@@ -11,7 +11,7 @@ class Message extends Component {
     let messageClass = fromMe ? 'chat-outgoing' : 'chat-incoming';
     
     let RFCDate = message.key.split('-')[0];
-    let date = formatRelative(Date.parse('Fri, 01 Sep 2016 03:42:50 GMT'), new Date());
+    let date = formatRelative(Date.parse(RFCDate), new Date());
 
     let emojified = emoji.replace_colons(message.msg);
 

--- a/src/components/chat/Message.js
+++ b/src/components/chat/Message.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { format, formatRelative } from 'date-fns';
+import { formatRelative } from 'date-fns';
 
 import emoji from '../../utils/emoji_convertor';
 import md from '../../utils/link_attr_blank';
@@ -11,7 +11,7 @@ class Message extends Component {
     let messageClass = fromMe ? 'chat-outgoing' : 'chat-incoming';
     
     let RFCDate = message.key.split('-')[0];
-    let date = formatRelative(Date.parse(RFCDate), new Date());
+    let date = formatRelative(Date.parse('Fri, 01 Sep 2016 03:42:50 GMT'), new Date());
 
     let emojified = emoji.replace_colons(message.msg);
 
@@ -33,7 +33,6 @@ class Message extends Component {
 
     // Render escaped HTML/Markdown
     let linked = md.render(emojiMD);
-
 
     return (
       <li className={'chat-message ' + messageClass} key={message.key}>

--- a/src/static/sass/_layout.scss
+++ b/src/static/sass/_layout.scss
@@ -195,6 +195,11 @@ main {
           width: 90%;
           word-wrap: break-word;
 
+          .message-header {
+            display: flex;
+            justify-content: space-between;
+          }
+
           .username {
             display: block;
             font-weight: bold;


### PR DESCRIPTION
#65

Adds timestamp to message. It's a barebones solution that can be refactored later if tooltips are used.
It uses [this library](https://date-fns.org/v2.0.0-alpha.2/docs/formatRelative).

Examples:
![screenshot_2017-09-02_20-47-21](https://user-images.githubusercontent.com/5697723/30000422-37e0f8be-9020-11e7-81a1-8d3150c3e00e.png)
![screenshot_2017-09-02_20-46-51](https://user-images.githubusercontent.com/5697723/30000423-37e266d6-9020-11e7-9a80-d23b4e7be871.png)
![screenshot_2017-09-02_20-45-49](https://user-images.githubusercontent.com/5697723/30000424-37e2af4c-9020-11e7-8729-743cfef1b212.png)


First time working in this codebase.... it's pretty funky, message keys are the timestamps whaaaat!