### PR TITLE
docker compose rework

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 node_modules/
+build/

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,16 +1,18 @@
 FROM golang:1.19-alpine
 
-WORKDIR /github.com/cryptag/leapchat/miniware
+RUN mkdir -p /app
 
-WORKDIR /github.com/cryptag/leapchat
+WORKDIR /app/github.com/cryptag/leapchat/miniware
+
+WORKDIR /app/github.com/cryptag/leapchat
 
 COPY miniware/* miniware/
 COPY *.go .
 COPY go.* .
 COPY LICENSE.md .
 
-RUN go build -o /leapchat
+RUN go build
 
 EXPOSE 8080
 
-CMD ["/leapchat"]
+CMD ["./leapchat"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,16 @@
+FROM golang:1.19-alpine
+
+WORKDIR /github.com/cryptag/leapchat/miniware
+
+WORKDIR /github.com/cryptag/leapchat
+
+COPY miniware/* miniware/
+COPY *.go .
+COPY go.* .
+COPY LICENSE.md .
+
+RUN go build -o /leapchat
+
+EXPOSE 8080
+
+CMD ["/leapchat"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+
+start:
+	docker compose up -d
+
+stop:
+	docker compose down
+
+restart:
+	docker compose restart
+
+build:
+	docker compose build
+
+buildup:
+	docker compose up -d --build
+
+cleanv:
+	docker compose down -v

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
 
+shell:
+	docker compose exec app /bin/sh
+
 start:
 	docker compose up -d
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     postgres:
         image: postgres:latest
         ports:
-            - 5432:5433
+            - 5433:5432
         environment:
             - POSTGRES_PASSWORD=superuser
             - POSTGRES_USER=superuser

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,34 @@
-version: '3.1'
+version: '3.4'
 
 services:
+    app:
+        build:
+            context: .
+            dockerfile: ./Dockerfile.dev
+        ports:
+            - 8080:8080
+        depends_on:
+            - postgrest
+        volumes:
+            - ./build:/build
     postgres:
         image: postgres:latest
         ports:
-            - 127.0.0.1:5432:5432
+            - 5432:5433
         environment:
             - POSTGRES_PASSWORD=superuser
             - POSTGRES_USER=superuser
             - POSTGRES_DB=leapchat
         volumes:
             - ./_docker-volumes/postgres:/var/lib/postgresql/data
+            #- ./db:/docker-entrypoint-initdb.d/
+        healthcheck:
+            test: ["CMD-SHELL", "pg_isready"]
+            interval: 5s
+            timeout: 60s
+            retries: 10
     postgrest:
+        command: postgrest /app/postgrest.conf
         image: postgrest/postgrest:latest
         ports:
             - 3000:3000
@@ -23,5 +40,8 @@ services:
             PGDATABASE: leapchat
             PGSCHEMA: public
             DB_ANON_ROLE: postgres
+        volumes:
+            - ./db/:/app
         depends_on:
-            - postgres
+            postgres:
+                condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
         depends_on:
             - postgrest
         volumes:
-            - ./build:/build
+            - ./build:/app/github.com/cryptag/leapchat/build
     postgres:
         image: postgres:latest
         ports:

--- a/leapchat.go
+++ b/leapchat.go
@@ -25,9 +25,9 @@ func init() {
 }
 
 func main() {
-	httpAddr := flag.String("http", "127.0.0.1:8080",
+	httpAddr := flag.String("http", "0.0.0.0:8080",
 		"Address to listen on HTTP")
-	httpsAddr := flag.String("https", "127.0.0.1:8443",
+	httpsAddr := flag.String("https", "0.0.0.0:8443",
 		"Address to listen on HTTPS")
 	domain := flag.String("domain", "", "Domain of this service")
 	iframeOrigin := flag.String("iframe-origin", "",
@@ -38,7 +38,7 @@ func main() {
 	flag.Parse()
 
 	if *onionPush {
-		*httpAddr = "127.0.0.1:5001"
+		*httpAddr = "0.0.0.0:5001"
 		BUILD_DIR = "public"
 	}
 


### PR DESCRIPTION
What's in this PR:

1. A Dockerfile was created for building the leapchat server as a go binary docker image.
2. A Dockerfile was created for building a frontend image.
3. Updated the docker compose file to build the frontend image, go server image, as well as the two database images.
4. Updated the docker-compose file database image steps to include passing the PostgREST config and running the init script in the `postgres` container.

WIP: have the sql init shell script run in the postgres container when it boots up.