### PR TITLE
Go: Prevent panic when removing client with nil wsConn (triggered in test)

### DIFF
--- a/room.go
+++ b/room.go
@@ -160,7 +160,9 @@ func (r *Room) RemoveClient(c *Client) {
 	for i, client := range r.Clients {
 		if client == c {
 			r.Clients = append(r.Clients[:i], r.Clients[i+1:]...)
-			client.wsConn.Close()
+			if client.wsConn != nil {
+				client.wsConn.Close()
+			}
 			break
 		}
 	}

--- a/room_test.go
+++ b/room_test.go
@@ -51,6 +51,8 @@ func TestRoomMessages(t *testing.T) {
 			err := r.AddMessages(msgs[i], &ttlSecs)
 			if err != nil {
 				t.Logf("Error from AddMessages: %s", err)
+
+				// FALLTHROUGH
 			}
 			wg.Done()
 		}(i)
@@ -59,6 +61,8 @@ func TestRoomMessages(t *testing.T) {
 			_, err := r.GetMessages()
 			if err != nil {
 				t.Logf("Error from GetMessages: %s", err)
+
+				// FALLTHROUGH
 			}
 			wg.Done()
 		}()


### PR DESCRIPTION
Fixes #266