### PR TITLE
Add toolbar control for toggling audio, persist preference between sessions

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -24,10 +24,15 @@ class App extends Component {
   constructor(props) {
     super(props);
 
+    // Default to false on initial render so audio doesn't attempt to play before 
+    // user interacts with page (which triggers console.error)
+    const isAudioEnabled = false;
+
     this.state = {
       showUsernameModal: false,
       showInfoModal: false,
-      showSettingsModal: false
+      showSettingsModal: false,
+      isAudioEnabled: isAudioEnabled,
     };
 
   }
@@ -77,6 +82,13 @@ class App extends Component {
     });
   }
 
+  onSetIsAudioEnabled = (isAudioEnabled) => {
+    this.setState({
+      isAudioEnabled: isAudioEnabled
+    });
+    localStorage.setItem("isAudioEnabled", isAudioEnabled);
+  }
+
   onSetPincode = (pincode = "") => {
     if (!pincode || pincode.endsWith("--")) {
       this.onError('Invalid pincode!');
@@ -104,7 +116,7 @@ class App extends Component {
   }
 
   render() {
-    const { showInfoModal, showSettingsModal } = this.state;
+    const { showInfoModal, showSettingsModal, isAudioEnabled } = this.state;
     const {
       messages,
       username,
@@ -140,7 +152,8 @@ class App extends Component {
             username={username}
             isVisible={showUsernameModal}
             onSetUsername={this.onSetUsername}
-            onCloseModal={this.onCloseUsernameModal} />}
+            onCloseModal={this.onCloseUsernameModal}
+            onSetIsAudioEnabled={this.onSetIsAudioEnabled} />}
 
           {showSettingsModal && <SettingsModal 
             isVisible={showSettingsModal}
@@ -153,7 +166,9 @@ class App extends Component {
             messages={messages}
             username={username}
             onSendMessage={this.onSendMessage}
-            messageInputFocus={chatInputFocus} />
+            messageInputFocus={chatInputFocus}
+            isAudioEnabled={isAudioEnabled}
+            onSetIsAudioEnabled={this.onSetIsAudioEnabled} />
 
           <InfoModal
             showModal={showInfoModal}

--- a/src/components/chat/ChatContainer.js
+++ b/src/components/chat/ChatContainer.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import { PropTypes } from 'prop-types';
 import { connect } from 'react-redux';
 
 import MessageBox from './MessageBox';
@@ -8,7 +9,17 @@ import AutoSuggest from './AutoSuggest';
 
 class ChatContainer extends Component {
   render() {
-    const { messages, username, onSendMessage, alertMessage, alertStyle, onAlertDismiss, chat } = this.props;
+    const {
+      messages,
+      username,
+      onSendMessage,
+      alertMessage,
+      alertStyle,
+      onAlertDismiss,
+      messageInputFocus,
+      chat,
+      isAudioEnabled,
+      onSetIsAudioEnabled } = this.props;
 
     return (
       <div className="content">
@@ -20,17 +31,33 @@ class ChatContainer extends Component {
 
         <MessageBox
           messages={messages}
-          username={username} />
+          username={username} 
+          isAudioEnabled={isAudioEnabled} />
 
         {chat.suggestions.length > 0 && <AutoSuggest />}
 
         <MessageForm
           onSendMessage={onSendMessage}
-          shouldHaveFocus={this.props.messageInputFocus} />
+          shouldHaveFocus={messageInputFocus}
+          isAudioEnabled={isAudioEnabled}
+          onSetIsAudioEnabled={onSetIsAudioEnabled} />
 
       </div>
     );
   }
 }
+
+ChatContainer.propTypes = {
+  messages: PropTypes.array.isRequired,
+  username: PropTypes.string.isRequired,
+  onSendMessage: PropTypes.func.isRequired,
+  alertMessage: PropTypes.string,
+  alertStyle: PropTypes.string,
+  onAlertDismiss: PropTypes.func,
+  messageInputFocus: PropTypes.bool.isRequired,
+  chat: PropTypes.object.isRequired,
+  isAudioEnabled: PropTypes.bool.isRequired,
+  onSetIsAudioEnabled: PropTypes.func.isRequired,
+};
 
 export default connect(({ chat }) => ({ chat }))(ChatContainer);

--- a/src/components/chat/MessageBox.js
+++ b/src/components/chat/MessageBox.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 
 import MessageList from './MessageList';
-import Throbber from '../general/Throbber';
 import { connect } from 'react-redux';
 import { closePicker } from '../../actions/chatActions';
 import { playNotification } from '../../utils/audio';
@@ -16,8 +15,14 @@ class MessageBox extends Component {
     };
   }
 
+  onNewMessages = () => {
+    if (this.props.isAudioEnabled){
+      playNotification();
+    }
+    this.scrollToBottom();
+  }
+
   scrollToBottom = () => {
-    playNotification();
     this.messagesEnd && this.messagesEnd.scrollIntoView();
   }
 
@@ -32,7 +37,10 @@ class MessageBox extends Component {
     return (
       <div className="message-box" onClick={closePicker}>
         <div className="message-list">
-          <MessageList onNewMessages={this.scrollToBottom} messages={messages} username={username} />
+          <MessageList
+            onNewMessages={() => this.onNewMessages()}
+            messages={messages}
+            username={username} />
         </div>
         <div style={{float: "left", clear: "both"}}
           ref={this.setMessagesEndRef}>

--- a/src/components/chat/MessageForm.js
+++ b/src/components/chat/MessageForm.js
@@ -1,10 +1,11 @@
 import React, { Component } from 'react';
-import ReactDOM from 'react-dom';
+import { PropTypes } from 'prop-types';
+import { connect } from 'react-redux';
+
 import { Button } from 'react-bootstrap';
 import FaArrowCircleRight from 'react-icons/lib/fa/arrow-circle-right';
 import FaSmileO from 'react-icons/lib/fa/smile-o';
 import { Picker } from 'emoji-mart';
-import { connect } from 'react-redux';
 import emoji from '../../constants/emoji';
 import { emojiSuggestions, mentionSuggestions } from '../../utils/suggestions';
 import {
@@ -19,6 +20,7 @@ import {
   upSuggestion,
   addSuggestion
 } from '../../actions/chatActions';
+import ToggleAudioIcon from './toolbar/ToggleAudioIcon';
 
 class MessageForm extends Component {
   constructor(props) {
@@ -132,7 +134,11 @@ class MessageForm extends Component {
 
   render() {
     const { message, showEmojiPicker } = this.props.chat;
-    const { messageUpdate, togglePicker } = this.props;
+    const {
+      messageUpdate,
+      togglePicker,
+      isAudioEnabled,
+      onSetIsAudioEnabled } = this.props;
 
     return (
       <div className="message-form">
@@ -157,9 +163,14 @@ class MessageForm extends Component {
                 onClick={togglePicker}
               />
 
-              <div className="right-chat-icons"></div>
-            </div>
+              <ToggleAudioIcon
+                isAudioEnabled={isAudioEnabled}
+                onSetIsAudioEnabled={onSetIsAudioEnabled} />
 
+              <div className="right-chat-icons"></div>
+            </div>  
+
+            
             <div className="message" onKeyDown={this.handleKeyDown}>
               <textarea
                 className="form-control"
@@ -175,13 +186,21 @@ class MessageForm extends Component {
                 <FaArrowCircleRight size={30} />
               </Button>
             </div>
-          </div>
 
+          </div>
         </form>
+
       </div>
     );
   }
 }
+
+MessageForm.propType = {
+  onSendMessage: PropTypes.func.isRequired,
+  shouldHaveFocus: PropTypes.bool.isRequired,
+  onSetIsAudioEnabled: PropTypes.func.isRequired,
+  isAudioEnabled: PropTypes.bool.isRequired,
+};
 
 export default connect(({ chat }) => ({chat}), {
   messageUpdate,

--- a/src/components/chat/MessageForm.js
+++ b/src/components/chat/MessageForm.js
@@ -168,7 +168,7 @@ class MessageForm extends Component {
                 onSetIsAudioEnabled={onSetIsAudioEnabled} />
 
               <div className="right-chat-icons"></div>
-            </div>  
+            </div>
 
             
             <div className="message" onKeyDown={this.handleKeyDown}>

--- a/src/components/chat/UserIcon.js
+++ b/src/components/chat/UserIcon.js
@@ -3,16 +3,14 @@ import PropTypes from 'prop-types';
 
 import FaGroup from 'react-icons/lib/fa/group';
 
-class UserIcon extends Component {
+const UserIcon = ({ onToggleUserList }) => {
 
-  render() {
-    return (
-      <div className="users-icon">
-        <FaGroup size={30} onClick={this.props.onToggleUserList} />
-      </div>
-    );
-  }
-}
+  return (
+    <div className="users-icon">
+      <FaGroup size={30} onClick={onToggleUserList} />
+    </div>
+  );
+};
 
 UserIcon.propTypes = {
   onToggleUserList: PropTypes.func.isRequired

--- a/src/components/chat/toolbar/ToggleAudioIcon.js
+++ b/src/components/chat/toolbar/ToggleAudioIcon.js
@@ -1,0 +1,43 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+import { Tooltip, OverlayTrigger } from 'react-bootstrap';
+
+import FaVolumeUp from 'react-icons/lib/fa/volume-up';
+import FaVolumeOff from 'react-icons/lib/fa/volume-off';
+
+const disableAudioTooltip = (
+  <Tooltip id="mute-audio">Mute Audio</Tooltip>
+);
+
+const enableAudioTooltip = (
+  <Tooltip id="enable-audio">Enable Audio</Tooltip>
+);
+
+const DisableAudioIcon = ({ onSetIsAudioEnabled }) => (
+  <OverlayTrigger overlay={disableAudioTooltip} placement="top" delayShow={300} delayHide={150}>
+    <FaVolumeUp size={24}  onClick={() => onSetIsAudioEnabled(false)} />
+  </OverlayTrigger>
+);
+
+const EnableAudioIcon = ({ onSetIsAudioEnabled }) => (
+  <OverlayTrigger overlay={enableAudioTooltip} placement="top" delayShow={300} delayHide={150}>
+    <FaVolumeOff size={24} onClick={() => onSetIsAudioEnabled(true)} />
+  </OverlayTrigger>
+);
+
+const ToggleAudioIcon = ({ isAudioEnabled, onSetIsAudioEnabled }) => {
+  return (
+    <div className="toggle-audio">
+      {isAudioEnabled && <DisableAudioIcon onSetIsAudioEnabled={onSetIsAudioEnabled} />}
+      {!isAudioEnabled && <EnableAudioIcon onSetIsAudioEnabled={onSetIsAudioEnabled} />}
+    </div>
+  );
+};
+
+ToggleAudioIcon.propTypes = {
+  onSetIsAudioEnabled: PropTypes.func.isRequired,
+  isAudioEnabled: PropTypes.bool.isRequired,
+};
+
+export default ToggleAudioIcon;

--- a/src/components/modals/Username.js
+++ b/src/components/modals/Username.js
@@ -46,6 +46,12 @@ class UsernameModal extends PureComponent {
 
     if (this.isUsernameValid(username)) {
       this.props.onSetUsername(username);
+      // set the audio to the user's previously selected preference; enable by default
+      let isAudioEnabled = JSON.parse(localStorage.getItem('isAudioEnabled'));
+      if (isAudioEnabled !== false) {
+        isAudioEnabled = true;
+      }
+      this.props.onSetIsAudioEnabled(isAudioEnabled);
     }
   }
 
@@ -112,7 +118,8 @@ UsernameModal.propTypes = {
   previousUsername: PropTypes.string.isRequired,
   username: PropTypes.string.isRequired,
   onCloseModal: PropTypes.func.isRequired,
-  onSetUsername: PropTypes.func.isRequired
+  onSetUsername: PropTypes.func.isRequired,
+  onSetIsAudioEnabled: PropTypes.func.isRequired,
 };
 
 export default UsernameModal;

--- a/src/components/modals/Username.js
+++ b/src/components/modals/Username.js
@@ -47,10 +47,7 @@ class UsernameModal extends PureComponent {
     if (this.isUsernameValid(username)) {
       this.props.onSetUsername(username);
       // set the audio to the user's previously selected preference; enable by default
-      let isAudioEnabled = JSON.parse(localStorage.getItem('isAudioEnabled'));
-      if (isAudioEnabled !== false) {
-        isAudioEnabled = true;
-      }
+      let isAudioEnabled = JSON.parse(localStorage.getItem('isAudioEnabled') || 'true');
       this.props.onSetIsAudioEnabled(isAudioEnabled);
     }
   }

--- a/src/static/sass/_layout.scss
+++ b/src/static/sass/_layout.scss
@@ -336,6 +336,7 @@ textarea {
   flex-direction: row;
   margin-bottom: 5px;
   width: 100%;
+  padding-left: 5px;
   gap: 5px;
 }
 .chat-icons .right-chat-icons {

--- a/src/static/sass/_layout.scss
+++ b/src/static/sass/_layout.scss
@@ -336,6 +336,7 @@ textarea {
   flex-direction: row;
   margin-bottom: 5px;
   width: 100%;
+  gap: 5px;
 }
 .chat-icons .right-chat-icons {
   display: flex;


### PR DESCRIPTION
This PR introduces an option to mute the audio in the LeapChat browser window.

We haven't discussed audio design; perhaps this should be configurable in settings at a more granular level, ie "play sound for all new message", "play sound only when I am mentioned in a message", etc.) But **_at a minimum_**, the user should be able to turn it off.

What this PR does:
1. When the user first loads the window and is presented with the "Set Username" dialog, don't play the audio in the background. This triggers a JS console error.
2. Once the Username modal is dismissed, check if the user has previously set an audio-enabled preference. If so, default to that, else just enable it by default.
3. An icon on the chat toolbar that allows for toggling the audio-enabled preference. This is persisted to the App state so it affects the session immediately and is persisted to localStorage to be used in future visits / sessions.
4. Also, there are some React annotations, like prop types for components, blah blah.

![toggle-audio](https://user-images.githubusercontent.com/89764/219478902-ac0a786b-718e-425d-90f0-b1bfcfd0e903.gif)
