### PR TITLE
Add drop shadow to message bubbles; hide your own username; distinct styling on username.

### DIFF
--- a/src/static/sass/_layout.scss
+++ b/src/static/sass/_layout.scss
@@ -176,24 +176,40 @@ main {
         padding-top: 5px;
 
       ul {
+        margin-top: 10px;
+
         li.chat-message {
           display: inline-block;
-          border: solid 1px #eee;
+          border: solid 1px #aaa;
           border-radius: 10px;
           padding: 5px 10px;
-          margin-bottom: 5px;
+          margin-bottom: 6px;
           width: 90%;
           word-wrap: break-word;
+          box-shadow: 2px 1px 2px #aaa, -1px 0 1px #aaa;
 
           .username {
             display: block;
             font-weight: bold;
+            font-size: 0.85em;
+          }
+
+          p {
+            margin: 0 0 3px;
           }
 
           &.chat-outgoing {
             float: right;
             color: white;
             background-color: #663399;
+
+            p {
+              margin: 2px 0;
+            }
+
+            .username {
+              display: none;
+            }
 
             a {
               text-decoration: underline;
@@ -278,6 +294,7 @@ main {
         // for now, message box is viewport height
         // less display height of message form
         height: calc(100vh - 70px);
+        box-shadow: inset 2px 2px 2px #aaa;
       }
     }
   }


### PR DESCRIPTION
<img width="401" alt="Screenshot 2023-02-19 at 11 59 32 PM" src="https://user-images.githubusercontent.com/89764/220013240-005dbe44-6f5e-4fc0-ae74-bb98a98d1c49.png">

This PR:

1. Adds a slight drop shadow to the message bubbles and an inset drop shadow to the message box
2. Removes your username from your own messages
3. Centers the message text within your own message bubble.
4. Makes the username in other message bubbles slightly smaller so it's more easily distinguishable from message text.