### PR TITLE
Sharing modal

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -29,10 +29,21 @@ class App extends Component {
     const isAudioEnabled = false;
 
     this.state = {
-      showUsernameModal: false,
-      showInfoModal: false,
-      showSettingsModal: false,
       isAudioEnabled: isAudioEnabled,
+      modals: {
+        username: {
+          isVisible: false
+        },
+        info: {
+          isVisible: false
+        },
+        settings: {
+          isVisible: false
+        },
+        pincode: {
+          isVisible: false
+        }
+      }
     };
 
   }
@@ -52,30 +63,13 @@ class App extends Component {
     }
   }
 
-  onShowUsernameModal = () => {
+  onToggleModalVisibility = (modalName, isVisible) => {
+    let modalsState = {...this.state.modals};
+    modalsState[modalName].isVisible = isVisible;
     this.setState({
-      showUsernameModal: true
+      modals: modalsState
     });
   }
-
-  onCloseUsernameModal = () => {
-    this.setState({
-      showUsernameModal: false
-    });
-  }
-
-  onShowSettingsModal = () => {
-    this.setState({
-      showSettingsModal: true
-    });
-  }
-
-  onCloseSettingsModal = () => {
-    this.setState({
-      showSettingsModal: false
-    });
-  }
-
   onClosePincodeModal = () => {
     this.setState({
       showPincodeModal: false
@@ -99,15 +93,7 @@ class App extends Component {
 
   onSetUsername = (username) => {
     this.props.setUsername(username);
-    this.setState({
-      showUsernameModal: false
-    });
-  }
-
-  onToggleInfoModal = () => {
-    this.setState((prevState) => {
-      return { showInfoModal: !prevState.showInfoModal };
-    });
+    this.onToggleModalVisibility('username', false);
   }
 
   onSendMessage = (message) => {
@@ -116,7 +102,6 @@ class App extends Component {
   }
 
   render() {
-    const { showInfoModal, showSettingsModal, isAudioEnabled } = this.state;
     const {
       messages,
       username,
@@ -126,7 +111,12 @@ class App extends Component {
       pincodeRequired,
       previousUsername } = this.props;
 
-    let { showUsernameModal } = this.state;
+    const { isAudioEnabled } = this.state;
+
+    const showSettingsModal = this.state.modals.settings.isVisible;
+    const showInfoModal = this.state.modals.info.isVisible;
+
+    let showUsernameModal = this.state.modals.username.isVisible;
     showUsernameModal = !pincodeRequired && (showUsernameModal || username === '');
 
     const chatInputFocus = !pincodeRequired && !showUsernameModal && username !== '';
@@ -136,28 +126,30 @@ class App extends Component {
         <Header
           username={username}
           statuses={statuses}
-          onShowUsernameModal={this.onShowUsernameModal}
-          onShowSettingsModal={this.onShowSettingsModal}
-          onToggleInfoModal={this.onToggleInfoModal} />
+          onToggleModalVisibility={this.onToggleModalVisibility} />
 
         <main className="encloser">
 
           {pincodeRequired && <PincodeModal
             showModal={pincodeRequired}
             onSetPincode={this.onSetPincode}
-            onCloseModal={this.onClosePincodeModal} />}
+            onToggleModalVisibility={this.onToggleModalVisibility} />}
 
           {showUsernameModal && <UsernameModal
             previousUsername={previousUsername}
             username={username}
             isVisible={showUsernameModal}
             onSetUsername={this.onSetUsername}
-            onCloseModal={this.onCloseUsernameModal}
+            onToggleModalVisibility={this.onToggleModalVisibility}
             onSetIsAudioEnabled={this.onSetIsAudioEnabled} />}
 
           {showSettingsModal && <SettingsModal 
             isVisible={showSettingsModal}
-            onCloseModal={this.onCloseSettingsModal} />}
+            onToggleModalVisibility={this.onToggleModalVisibility} />}
+
+          {showInfoModal && <InfoModal
+            isVisible={showInfoModal}
+            onToggleModalVisibility={this.onToggleModalVisibility} />}
 
           <ChatContainer
             alertMessage={alertMessage}
@@ -169,10 +161,6 @@ class App extends Component {
             messageInputFocus={chatInputFocus}
             isAudioEnabled={isAudioEnabled}
             onSetIsAudioEnabled={this.onSetIsAudioEnabled} />
-
-          <InfoModal
-            showModal={showInfoModal}
-            onToggleInfoModal={this.onToggleInfoModal} />
 
         </main>
 

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -19,6 +19,7 @@ import UsernameModal from './modals/Username';
 import InfoModal from './modals/InfoModal';
 import PincodeModal from './modals/PincodeModal';
 import SettingsModal from './modals/SettingsModal';
+import SharingModal from './modals/SharingModal';
 
 class App extends Component {
   constructor(props) {
@@ -41,6 +42,9 @@ class App extends Component {
           isVisible: false
         },
         pincode: {
+          isVisible: false
+        },
+        sharing: {
           isVisible: false
         }
       }
@@ -115,6 +119,7 @@ class App extends Component {
 
     const showSettingsModal = this.state.modals.settings.isVisible;
     const showInfoModal = this.state.modals.info.isVisible;
+    const showSharingModal = this.state.modals.sharing.isVisible;
 
     let showUsernameModal = this.state.modals.username.isVisible;
     showUsernameModal = !pincodeRequired && (showUsernameModal || username === '');
@@ -151,6 +156,10 @@ class App extends Component {
             isVisible={showInfoModal}
             onToggleModalVisibility={this.onToggleModalVisibility} />}
 
+          {showSharingModal && <SharingModal
+            isVisible={showSharingModal}
+            onToggleModalVisibility={this.onToggleModalVisibility} />}
+
           <ChatContainer
             alertMessage={alertMessage}
             alertStyle={alertStyle}
@@ -160,7 +169,8 @@ class App extends Component {
             onSendMessage={this.onSendMessage}
             messageInputFocus={chatInputFocus}
             isAudioEnabled={isAudioEnabled}
-            onSetIsAudioEnabled={this.onSetIsAudioEnabled} />
+            onSetIsAudioEnabled={this.onSetIsAudioEnabled}
+            onToggleModalVisibility={this.onToggleModalVisibility} />
 
         </main>
 

--- a/src/components/chat/ChatContainer.js
+++ b/src/components/chat/ChatContainer.js
@@ -19,7 +19,8 @@ class ChatContainer extends Component {
       messageInputFocus,
       chat,
       isAudioEnabled,
-      onSetIsAudioEnabled } = this.props;
+      onSetIsAudioEnabled,
+      onToggleModalVisibility } = this.props;
 
     return (
       <div className="content">
@@ -40,7 +41,8 @@ class ChatContainer extends Component {
           onSendMessage={onSendMessage}
           shouldHaveFocus={messageInputFocus}
           isAudioEnabled={isAudioEnabled}
-          onSetIsAudioEnabled={onSetIsAudioEnabled} />
+          onSetIsAudioEnabled={onSetIsAudioEnabled}
+          onToggleModalVisibility={onToggleModalVisibility} />
 
       </div>
     );
@@ -58,6 +60,7 @@ ChatContainer.propTypes = {
   chat: PropTypes.object.isRequired,
   isAudioEnabled: PropTypes.bool.isRequired,
   onSetIsAudioEnabled: PropTypes.func.isRequired,
+  onToggleModalVisibility: PropTypes.func.isRequired,
 };
 
 export default connect(({ chat }) => ({ chat }))(ChatContainer);

--- a/src/components/chat/MessageForm.js
+++ b/src/components/chat/MessageForm.js
@@ -21,6 +21,7 @@ import {
   addSuggestion
 } from '../../actions/chatActions';
 import ToggleAudioIcon from './toolbar/ToggleAudioIcon';
+import InviteIcon from './toolbar/InviteIcon';
 
 class MessageForm extends Component {
   constructor(props) {
@@ -138,7 +139,8 @@ class MessageForm extends Component {
       messageUpdate,
       togglePicker,
       isAudioEnabled,
-      onSetIsAudioEnabled } = this.props;
+      onSetIsAudioEnabled,
+      onToggleModalVisibility } = this.props;
 
     return (
       <div className="message-form">
@@ -166,6 +168,9 @@ class MessageForm extends Component {
               <ToggleAudioIcon
                 isAudioEnabled={isAudioEnabled}
                 onSetIsAudioEnabled={onSetIsAudioEnabled} />
+
+              <InviteIcon
+                onToggleModalVisibility={onToggleModalVisibility} />
 
               <div className="right-chat-icons"></div>
             </div>
@@ -200,6 +205,7 @@ MessageForm.propType = {
   shouldHaveFocus: PropTypes.bool.isRequired,
   onSetIsAudioEnabled: PropTypes.func.isRequired,
   isAudioEnabled: PropTypes.bool.isRequired,
+  onToggleModalVisibility: PropTypes.func.isRequired,
 };
 
 export default connect(({ chat }) => ({chat}), {

--- a/src/components/chat/UserList.js
+++ b/src/components/chat/UserList.js
@@ -1,5 +1,8 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { Button } from 'react-bootstrap';
+
+import { FaShareAlt } from 'react-icons/fa';
 
 import { UserStatusIcon } from './UserStatusIcons';
 
@@ -29,9 +32,13 @@ class UserList extends Component {
       return { status, username };
     });
 
+    const onShowSharingModal = () => {
+      onToggleModalVisibility('sharing', true);
+    };
+
     return (
-      <div className="users-list">
-        <ul style={this.styleUserList()}>
+      <div className="users-list" style={this.styleUserList()}>
+        <ul>
           {userStatuses.map((userStatus, i) => {
             return (
               <li key={i}>
@@ -44,6 +51,12 @@ class UserList extends Component {
             );
           })}
         </ul>
+        <div className="invite-users" >
+          <Button className="icon-button" bsStyle="link" onClick={onShowSharingModal}>
+            Invite Users <FaShareAlt size={15} />
+          </Button>
+        </div>
+        
       </div>
     );
   }

--- a/src/components/chat/UserList.js
+++ b/src/components/chat/UserList.js
@@ -21,7 +21,7 @@ class UserList extends Component {
   }
 
   render() {
-    const { statuses, onShowUsernameModal } = this.props;
+    const { statuses, onToggleModalVisibility } = this.props;
     const currentUsername = this.props.username;
 
     const userStatuses = Object.keys(statuses).map(username => {
@@ -39,7 +39,7 @@ class UserList extends Component {
                   username={userStatus.username}
                   status={userStatus.status}
                   isCurrentUser={userStatus.username === currentUsername}
-                  onShowUsernameModal={onShowUsernameModal} />
+                  onToggleModalVisibility={onToggleModalVisibility} />
               </li>
             );
           })}
@@ -53,7 +53,7 @@ UserList.propTypes = {
   username: PropTypes.string.isRequired,
   statuses: PropTypes.object.isRequired,
   displayUserList: PropTypes.bool.isRequired,
-  onShowUsernameModal: PropTypes.func.isRequired
+  onToggleModalVisibility: PropTypes.func.isRequired
 };
 
 export default UserList;

--- a/src/components/chat/UserStatusIcons.js
+++ b/src/components/chat/UserStatusIcons.js
@@ -15,14 +15,20 @@ export const UserStatusIcon = ({
   username,
   status,
   isCurrentUser,
-  onShowUsernameModal
+  onToggleModalVisibility
 }) => {
+
+  const onShowUsernameModal = () => {
+    onToggleModalVisibility('username', true);
+  };
+
   let statusIcon = <FaMinusCircle style={styleOffline} />;
   if (status === 'viewing') {
     statusIcon = <FaCircle style={styleViewing} />;
   } else if (status === 'online') {
     statusIcon = <FaCircle style={styleOnline} />;
   }
+
   return (
     <div style={styleUserStatus}>
       {statusIcon}
@@ -43,7 +49,7 @@ UserStatusIcon.propTypes = {
   username: PropTypes.string.isRequired,
   status: PropTypes.string.isRequired,
   isCurrentUser: PropTypes.bool.isRequired,
-  onShowUsernameModal: PropTypes.func.isRequired
+  onToggleModalVisibility: PropTypes.func.isRequired
 };
 
 const styleUserStatus = {

--- a/src/components/chat/toolbar/InviteIcon.js
+++ b/src/components/chat/toolbar/InviteIcon.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { Tooltip, OverlayTrigger } from 'react-bootstrap';
+
+import { FaShareAltSquare } from 'react-icons/fa';
+
+const shareChatTooltip = (
+  <Tooltip id="share-chat">Invite to Chat</Tooltip>
+);
+
+const InviteIcon = ({ onToggleModalVisibility }) => {
+
+  const showSharingModal = () => {
+    onToggleModalVisibility('sharing', true);
+  };
+
+  return (
+    <div className="sharing">
+      <OverlayTrigger overlay={shareChatTooltip} placement="top" delayShow={300} delayHide={150}>
+        <FaShareAltSquare size={24} onClick={showSharingModal} />
+      </OverlayTrigger>
+    </div>
+  );
+};
+
+InviteIcon.propTypes = {
+  onToggleModalVisibility: PropTypes.func.isRequired
+};
+
+export default InviteIcon;

--- a/src/components/layout/Header.js
+++ b/src/components/layout/Header.js
@@ -24,9 +24,8 @@ class Header extends Component {
     const {
       username,
       statuses,
-      onShowUsernameModal,
-      onToggleInfoModal,
-      onShowSettingsModal
+      onToggleModalVisibility,
+      onShowUsernameModal
     } = this.props;
     const { displayUserList } = this.state;
     
@@ -35,17 +34,17 @@ class Header extends Component {
         <div className="logo-container">
           <div id="logo-info">
             <Logo />
-            <Info onToggleInfoModal={onToggleInfoModal}/>
+            <Info onToggleModalVisibility={onToggleModalVisibility}/>
           </div>
           <Settings
-            onShowSettingsModal={onShowSettingsModal} />
+            onToggleModalVisibility={onToggleModalVisibility} />
         </div>
         <UserIcon onToggleUserList={this.onToggleUserList} />
         <UserList
           username={username}
           statuses={statuses}
           displayUserList={displayUserList}
-          onShowUsernameModal={onShowUsernameModal} />
+          onToggleModalVisibility={onToggleModalVisibility} />
       </header>
     );
   }
@@ -54,9 +53,7 @@ class Header extends Component {
 Header.propTypes = {
   username: PropTypes.string.isRequired,
   statuses: PropTypes.object.isRequired,
-  onShowUsernameModal: PropTypes.func.isRequired,
-  onToggleInfoModal: PropTypes.func.isRequired,
-  onShowSettingsModal: PropTypes.func.isRequired
+  onToggleModalVisibility: PropTypes.func.isRequired
 };
 
 export default connect(null, { closePicker })(Header);

--- a/src/components/layout/Info.js
+++ b/src/components/layout/Info.js
@@ -8,22 +8,22 @@ const infoTooltip = (
   <Tooltip id="open-info-tooltip">Open LeapChat Info</Tooltip>
 );
 
-export default class Info extends Component {
-  constructor(props){
-    super(props);
-  }
-
-  render() {
-    return (
-      <div className="info">
-        <OverlayTrigger placement="bottom" overlay={infoTooltip} delayHide={150} delayShow={300}>
-          <FaInfoCircle onClick={this.props.onToggleInfoModal} size={25}/>
-        </OverlayTrigger>
-      </div>
-    );
-  }
-}
+const Info = ({ onToggleModalVisibility }) => {
+  const onClose = () => {
+    onToggleModalVisibility('info', true);
+  };
+  
+  return (
+    <div className="info">
+      <OverlayTrigger placement="bottom" overlay={infoTooltip} delayHide={150} delayShow={300}>
+        <FaInfoCircle onClick={onClose} size={25}/>
+      </OverlayTrigger>
+    </div>
+  );
+};
 
 Info.propTypes = {
-  onToggleInfoModal: PropTypes.func.isRequired
+  onToggleModalVisibility: PropTypes.func.isRequired
 };
+
+export default Info;

--- a/src/components/layout/Settings.js
+++ b/src/components/layout/Settings.js
@@ -9,7 +9,12 @@ const settingsTooltip = (
   <Tooltip id="open-settings-tooltip">Open Settings</Tooltip>
 );
 
-const Settings = ({ onShowSettingsModal }) => {
+const Settings = ({ onToggleModalVisibility }) => {
+
+  const onShowSettingsModal = () => {
+    onToggleModalVisibility('settings', true);
+  };
+
   return (
     <div className="settings" >
       <OverlayTrigger placement="bottom" overlay={settingsTooltip} delayShow={300} delayHide={150}>
@@ -20,7 +25,7 @@ const Settings = ({ onShowSettingsModal }) => {
 };
 
 Settings.propTypes = {
-  onShowSettingsModal: PropTypes.func.isRequired
+  onToggleModalVisibility: PropTypes.func.isRequired
 };
 
 export default Settings;

--- a/src/components/modals/InfoModal.js
+++ b/src/components/modals/InfoModal.js
@@ -2,59 +2,60 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Modal } from 'react-bootstrap';
 
-export default class InfoModal extends Component {
-  constructor(props){
-    super(props);
-  }
+const InfoModal = ({ isVisible, onToggleModalVisibility }) => {
 
-  render() {
-    return (
-      <Modal show={this.props.showModal} onHide={this.props.onToggleInfoModal}>
-        <Modal.Header closeButton>
-          <h3>Welcome to LeapChat!</h3>
-          <h4>LeapChat: encrypted, ephemeral, in-browser chat.</h4>
-        </Modal.Header>
-        <Modal.Body>
-          <p>Just visit <a href="https://www.leapchat.org/" target="_blank">leapchat.org</a> and a new, secure chat room will instantly be created for you. And once you're in, just link people to that page to invite them to join you!</p>
-          <h3>
-            Why LeapChat?
-          </h3>
-          <p>
-            You shouldn't have to sacrifice your privacy and personal information just to chat online. Slack, HipChat, and others make you create an account with your email address, their software doesn't encrypt your messages (they can see everything), and the messages last forever unless you manually delete them.
-            In contrast, LeapChat <em>does</em> encrypt your messages (even we can't see them!), <em>doesn't</em> require you to hand over your email address, and messages last for a maximum of 90 days (this will soon be configurable to a shorter duration).
-            Plus, you can host LeapChat on your own server, since it's <a href="https://github.com/cryptag/leapchat" target="_blank">open source</a>!
-          </p>
-          <h3>
-            How does it work?
-          </h3>
-          <div>
-            When click on a link to a LeapChat room:
-            <ol>
-              <li>
-                Your browser loads the HTML, CSS, and JavaScript from the server (e.g., leapchat.org)
-              </li>
-              <li>
-                That JavaScript code then grabs the long passphrase at the end of the URL (the "URL hash" -- everything after the `#`), then passes it to <a href="https://github.com/kaepora/minilock" target="_blank">miniLock</a>, which then deterministically generates a keypair from that passphrase
-              </li>
-              <li>
-                That cryptographic keypair is then used by your browser (and every other chat participant) to encrypt and decrypt messages to and from the people you're chatting with
-              </li>
-            </ol>
-            The server can't even see your username!  That's encrypted, too, and is attached to the messages you send.
-          </div>
-          <h3>
-            Can I type markdown in my messages?
-          </h3>
-          <p>
-            <em>Yup!</em> To learn about Markdown syntax, like surrounding words with **double asterisks** to make them <b>bold</b>, or with _underscores_ to make them <i>italicized</i>, <a href="https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet" target="_blank">check out this guide</a>.
-          </p>
-        </Modal.Body>
-      </Modal>
-    );
-  }
-}
+  const onClose = () => {
+    onToggleModalVisibility('info', false);
+  };
 
+  return (
+    <Modal show={isVisible} onHide={onClose}>
+      <Modal.Header closeButton>
+        <h3>Welcome to LeapChat!</h3>
+        <h4>LeapChat: encrypted, ephemeral, in-browser chat.</h4>
+      </Modal.Header>
+      <Modal.Body>
+        <p>Just visit <a href="https://www.leapchat.org/" target="_blank">leapchat.org</a> and a new, secure chat room will instantly be created for you. And once you're in, just link people to that page to invite them to join you!</p>
+        <h3>
+          Why LeapChat?
+        </h3>
+        <p>
+          You shouldn't have to sacrifice your privacy and personal information just to chat online. Slack, HipChat, and others make you create an account with your email address, their software doesn't encrypt your messages (they can see everything), and the messages last forever unless you manually delete them.
+          In contrast, LeapChat <em>does</em> encrypt your messages (even we can't see them!), <em>doesn't</em> require you to hand over your email address, and messages last for a maximum of 90 days (this will soon be configurable to a shorter duration).
+          Plus, you can host LeapChat on your own server, since it's <a href="https://github.com/cryptag/leapchat" target="_blank">open source</a>!
+        </p>
+        <h3>
+          How does it work?
+        </h3>
+        <div>
+          When you click on a link to a LeapChat room:
+          <ol>
+            <li>
+              Your browser loads the HTML, CSS, and JavaScript from the server (e.g., leapchat.org)
+            </li>
+            <li>
+              That JavaScript code then grabs the long passphrase at the end of the URL (the "URL hash" -- everything after the `#`), then passes it to <a href="https://github.com/kaepora/minilock" target="_blank">miniLock</a>, which then deterministically generates a keypair from that passphrase
+            </li>
+            <li>
+              That cryptographic keypair is then used by your browser (and every other chat participant) to encrypt and decrypt messages to and from the people you're chatting with
+            </li>
+          </ol>
+          The server can't even see your username!  That's encrypted, too, and is attached to the messages you send.
+        </div>
+        <h3>
+          Can I type markdown in my messages?
+        </h3>
+        <p>
+          <em>Yup!</em> To learn about Markdown syntax, like surrounding words with **double asterisks** to make them <b>bold</b>, or with _underscores_ to make them <i>italicized</i>, <a href="https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet" target="_blank">check out this guide</a>.
+        </p>
+      </Modal.Body>
+    </Modal>
+  );
+};
 
 InfoModal.propTypes = {
-  onToggleInfoModal: PropTypes.func.isRequired
+  isVisible: PropTypes.bool.isRequired,
+  onToggleModalVisibility: PropTypes.func.isRequired
 };
+
+export default InfoModal;

--- a/src/components/modals/PincodeModal.js
+++ b/src/components/modals/PincodeModal.js
@@ -44,12 +44,16 @@ class PincodeModal extends PureComponent {
     this.pincodeInput.value = genPassphrase(2);
   }
 
+  onClose = () => {
+    this.props.onToggleModalVisibility('pincode', false);
+  }
+
   render() {
-    let { showModal, pincode, onCloseModal } = this.props;
+    let { showModal, pincode } = this.props;
 
     return (
       <div>
-        <Modal show={showModal} onHide={this.onCloseModal}>
+        <Modal show={showModal} onHide={this.onClose}>
           <Modal.Header>
             <Modal.Title>Set Pincode</Modal.Title>
           </Modal.Header>
@@ -68,7 +72,7 @@ class PincodeModal extends PureComponent {
             </div>
           </Modal.Body>
           <Modal.Footer>
-            {pincode && <Button onClick={onCloseModal}>Cancel</Button>}
+            {pincode && <Button onClick={this.onClose}>Cancel</Button>}
             <Button onClick={this.onSetPincodeClick} bsStyle="primary">Set Pincode</Button>
           </Modal.Footer>
         </Modal>
@@ -80,7 +84,7 @@ class PincodeModal extends PureComponent {
 
 PincodeModal.propType = {
   showModal: PropTypes.bool.isRequired,
-  onCloseModal: PropTypes.func.isRequired,
+  onToggleModalVisibility: PropTypes.func.isRequired,
   onSetPincode: PropTypes.func.isRequired
 };
 

--- a/src/components/modals/SettingsModal.js
+++ b/src/components/modals/SettingsModal.js
@@ -26,12 +26,16 @@ const tooltip = (
 
 const SettingsModal = ({
   isVisible,
-  onCloseModal
+  onToggleModalVisibility
 }) => {
+
+  const onClose = () => {
+    onToggleModalVisibility('settings', false);
+  };
 
   return (
     <div>
-      <Modal show={isVisible} onHide={onCloseModal}>
+      <Modal show={isVisible} onHide={onClose}>
         <Modal.Header closeButton>
           <h2>Settings</h2>
         </Modal.Header>
@@ -74,7 +78,7 @@ const SettingsModal = ({
 
 SettingsModal.propTypes = {
   isVisible: PropTypes.bool.isRequired,
-  onCloseModal: PropTypes.func.isRequired,
+  onToggleModalVisibility: PropTypes.func.isRequired,
 
 };
 

--- a/src/components/modals/SettingsModal.js
+++ b/src/components/modals/SettingsModal.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { Modal, Button, OverlayTrigger, Tooltip } from 'react-bootstrap';
-import { FaShareAlt } from 'react-icons/fa';
 import { FaExternalLinkAlt } from 'react-icons/fa';
 
 import { chatHandler } from '../../epics/chatEpics';
@@ -12,17 +11,6 @@ const onDeleteAllMsgs = (e) => {
     chatHandler.sendDeleteAllMessagesSignalToServer();
   }
 };
-
-const onCopyShareLink = (e) => {
-  const shareLink = window.location.href;
-  navigator.clipboard.writeText(shareLink);
-};
-
-const tooltip = (
-  <Tooltip id="confirm-copy">
-    <strong>Link copied!</strong>
-  </Tooltip>
-);
 
 const SettingsModal = ({
   isVisible,
@@ -37,20 +25,9 @@ const SettingsModal = ({
     <div>
       <Modal show={isVisible} onHide={onClose}>
         <Modal.Header closeButton>
-          <h2>Settings</h2>
+          <Modal.Title>Settings</Modal.Title>
         </Modal.Header>
         <Modal.Body>
-          <hr />
-          <h3>Invite to this Chat</h3>
-          <p>
-            Click to copy a link to your clipboard to invite others to this LeapChat room.
-          </p>
-          <OverlayTrigger placement="top" overlay={tooltip} trigger="click" delayHide={500}>
-            <Button onClick={onCopyShareLink} bsStyle="primary" style={{display: 'flex', flexDirection: 'row', alignItems: 'center'}}>
-              Copy Link to Clipboard <div style={{width: '4px'}}></div><FaShareAlt />
-            </Button>
-          </OverlayTrigger>
-          <hr />
           <h3>Feedback</h3>
           <p>
             Do you have feedback or suggestions on how we can improve LeapChat? We're listening!{' '}

--- a/src/components/modals/SharingModal.js
+++ b/src/components/modals/SharingModal.js
@@ -1,0 +1,85 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { Modal, Button, OverlayTrigger, Tooltip } from 'react-bootstrap';
+import { FaShareAlt } from 'react-icons/fa';
+import { FaShareAltSquare } from 'react-icons/fa';
+
+const onCopyShareLink = (e) => {
+  navigator.clipboard.writeText(window.location.href);
+};
+
+const onShareLink = (e) => {
+  navigator.share({
+    url: window.location.href,
+    title: "LeapChat",
+    text: "Join me on LeapChat"
+  });
+};
+
+const copyLinkTooltip = (
+  <Tooltip id="confirm-copy">
+    <strong>Link copied!</strong>
+  </Tooltip>
+);
+
+const SharingModal = ({
+  isVisible,
+  onToggleModalVisibility
+}) => {
+
+  const onClose = () => {
+    onToggleModalVisibility('sharing', false);
+  };
+
+  return (
+    <div>
+      <Modal show={isVisible} onHide={onClose}>
+        <Modal.Header closeButton>
+          <Modal.Title>Invite to Chat</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          { navigator.share && <div>
+            <h3>Share Link</h3>
+            <p>
+              Invite with a link shared via SMS, Email, etc.
+            </p>
+            <Button className="icon-button" onClick={onShareLink} bsStyle="primary">
+              Share Link <FaShareAltSquare />
+            </Button>
+            <hr />
+          </div>
+          }
+
+          <h3>Copy Link</h3>
+          <p>Invite with a link copied to your clipboard.</p>
+          <div className="form-group share-copy-link">
+            <form role="form" className="form-inline">
+              <input className="form-control current-href" type="text" readOnly value={window.location.href} />
+              <OverlayTrigger
+                trigger="click"
+                overlay={copyLinkTooltip}
+                placement="top"
+                delayShow={300}
+                delayHide={150}>
+                <Button className="icon-button" bsStyle="primary">
+                  Copy to Clipboard
+                  <FaShareAlt size={15} />
+                </Button>
+              </OverlayTrigger>
+            </form>
+          </div>
+
+        </Modal.Body>
+      </Modal>
+    </div>
+  );
+};
+
+SharingModal.propTypes = {
+  isVisible: PropTypes.bool.isRequired,
+  onToggleModalVisibility: PropTypes.func.isRequired,
+
+};
+
+export default SharingModal;

--- a/src/components/modals/Username.js
+++ b/src/components/modals/Username.js
@@ -65,17 +65,20 @@ class UsernameModal extends PureComponent {
     }
   }
 
+  onClose = () => {
+    this.props.onToggleModalVisibility('username', false);
+  }
+
   render() {
     const {
       isVisible,
       previousUsername,
-      username,
-      onCloseModal
+      username
     } = this.props;
 
     return (
       <div>
-        <Modal show={isVisible} onHide={onCloseModal}>
+        <Modal show={isVisible} onHide={this.onClose}>
           <Modal.Header>
             <Modal.Title>Set Username</Modal.Title>
           </Modal.Header>
@@ -101,7 +104,7 @@ class UsernameModal extends PureComponent {
             </div>
           </Modal.Body>
           <Modal.Footer>
-            {username && <Button onClick={onCloseModal}>Cancel</Button>}
+            {username && <Button onClick={this.onClose}>Cancel</Button>}
             <Button data-testid="set-username" onClick={this.onSetUsernameClick} bsStyle="primary">Set Username</Button>
           </Modal.Footer>
         </Modal>
@@ -114,7 +117,7 @@ UsernameModal.propTypes = {
   isVisible: PropTypes.bool.isRequired,
   previousUsername: PropTypes.string.isRequired,
   username: PropTypes.string.isRequired,
-  onCloseModal: PropTypes.func.isRequired,
+  onToggleModalVisibility: PropTypes.func.isRequired,
   onSetUsername: PropTypes.func.isRequired,
   onSetIsAudioEnabled: PropTypes.func.isRequired,
 };

--- a/src/static/sass/_layout.scss
+++ b/src/static/sass/_layout.scss
@@ -65,16 +65,41 @@ header {
     }
   }
 
+  .icon-button {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: none;
+    }
+
+    svg {
+      margin: 0 4px;
+    }
+  }
+
   .users-list {
     flex: 0 1 100%;
 
     ul {
-      display: none;
+      
       list-style-type: none;
       li {
         svg {
           float: left;
         }
+      }
+    }
+
+    .invite-users {
+      margin-top: 15px;
+
+      button {
+        color: white;
+        border: solid 1px white;
+        border-radius: 5px;
       }
     }
   }
@@ -127,9 +152,10 @@ header {
     .users-list {
       flex-grow: 0;
       flex: none;
+      display: block !important;
 
       ul {
-        display: block !important;
+        
         li {
           margin-bottom: 1px;
           word-wrap: break-word;
@@ -140,7 +166,7 @@ header {
   .modal-header {
     border-bottom: none;
   }
-  .message{
+  .message {
     display: flex;
     flex-direction: row;
   }
@@ -150,6 +176,25 @@ header {
   }
   .emoji-picker-icon {
     cursor: pointer;
+  }
+}
+
+// Sharing overlay - desktop settings
+@media (min-width: 768px) {
+  .share-copy-link {
+    .current-href {
+      width: 60%;
+    }
+  }
+}
+
+// Sharing overlay - mobile settings
+@media (max-width: 768px) {
+  .share-copy-link {
+    .current-href {
+      width: 100%;
+      margin-bottom: 5px;
+    }
   }
 }
 
@@ -338,6 +383,11 @@ textarea {
   width: 100%;
   padding-left: 5px;
   gap: 10px;
+
+  .sharing,
+  .toggle-audio {
+    cursor: pointer;
+  }
 }
 .chat-icons .right-chat-icons {
   display: flex;

--- a/test/playwright/InviteUsers.spec.js
+++ b/test/playwright/InviteUsers.spec.js
@@ -1,0 +1,45 @@
+import { test, expect } from '@playwright/test';
+
+const username = "LeapChatUser";
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("http://localhost:8080/");
+  await page.locator("#username").fill(username);
+  await page.getByTestId("set-username").click();
+});
+
+test.describe("Opens sharing modal", () => {
+  test("opens and closes the invite users modal by clicking gear icon", async ({ page }) => {
+    await expect(page.getByText("Invite to Chat")).not.toBeVisible();
+
+    await page.locator(".sharing").click();
+    await expect(page.getByText("Invite to Chat")).toBeVisible();
+
+    await page.locator(".modal-header .close").click();
+    await expect(page.getByText("Invite to Chat")).not.toBeVisible();
+  });
+
+  test("opens and closes the invite users modal by clicking invite button in users list", async ({ page }) => {
+    await expect(page.getByText("Invite to Chat")).not.toBeVisible();
+
+    await page.locator(".invite-users .icon-button").click();
+    await expect(page.getByText("Invite to Chat")).toBeVisible();
+
+    await page.locator(".modal-header .close").click();
+    await expect(page.getByText("Invite to Chat")).not.toBeVisible();
+  });
+
+  test("copies invite link to browser clipboard", async ({ page }) => {
+    await page.locator(".sharing").click();
+    await expect(page.getByText("Invite to Chat")).toBeVisible();
+
+    // in order to check navigator.clipboard.readText(), we need to give playwright
+    //    permissions. Only chromium (not currently running) supports allowing this.
+    // Just check that we see the tooltip appear.
+    await expect(page.getByText("Link copied!")).not.toBeVisible();
+    await page.locator(".share-copy-link .icon-button").click();
+    await expect(page.getByText("Link copied!")).toBeVisible();
+    
+  });
+
+});

--- a/test/playwright/SettingsModal.spec.js
+++ b/test/playwright/SettingsModal.spec.js
@@ -19,19 +19,6 @@ test.describe("Opens settings modal", () => {
     await expect(page.getByText("Settings")).not.toBeVisible();
   });
 
-  test("copies invite link to browser clipboard", async ({ page }) => {
-    await page.locator(".settings").click();
-    await expect(page.getByText("Settings")).toBeVisible();
-
-    // in order to check navigator.clipboard.readText(), we need to give playwright
-    //    permissions. Only chromium (not currently running) supports allowing this.
-    // Just check that we see the tooltip appear.
-    await expect(page.getByText("Link copied!")).not.toBeVisible();
-    await page.locator(".modal-body .btn-primary").click();
-    await expect(page.getByText("Link copied!")).toBeVisible();
-    
-  });
-
   test("purges chat of all messages when delete all message button is clicked", async ({ page }) => {
     // TODO configure a whole mess of messages in the DOM from multiple users, then check that DOM is 
     //  cleared of all message bubble elements on page refresh.


### PR DESCRIPTION
What's in this PR:

1. Create a single helper method for showing / hiding modals by their name so we reduce the number of functions we drill down as props.
2. Create a separate sharing, invite users modal that contains a means of sharing via the Web Share API, when supported, and allows for copying a link to share, as previously allowed.
3. Add a trigger to open the invite users modal to the Message toolbar and as a button under the users list.

Inviting users should be as easy and discoverable as possible. I felt it needed to be pulled out of the Settings modal where it was buried.

Demo, in desktop Chrome (does not support Web Share API) and desktop Safari (which does support Web Share API):

![invite-users](https://user-images.githubusercontent.com/89764/219983058-7c64af2c-0941-46b4-a91b-cd7fff4f1956.gif)
