### PR TITLE
Welcome loading and connecting dialogue

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -16,6 +16,9 @@ import ChatContainer from './chat/ChatContainer';
 import PincodeModal from './modals/PincodeModal';
 import UsernameModal from './modals/Username';
 
+// evaluate on initial render only, not on every re-render.
+const isNewRoom = Boolean(!document.location.hash);
+
 class App extends Component {
   constructor(props) {
     super(props);
@@ -90,7 +93,11 @@ class App extends Component {
     const {
       username,
       pincodeRequired,
-      previousUsername } = this.props;
+      previousUsername,
+      authenticating,
+      connecting,
+      connected,
+    } = this.props;
 
     let showUsernameModal = this.state.modals.username.isVisible;
     showUsernameModal = !pincodeRequired && (showUsernameModal || username === '');
@@ -112,7 +119,11 @@ class App extends Component {
           previousUsername={previousUsername}
           username={username}
           isVisible={showUsernameModal}
+          isNewRoom={isNewRoom}
           setUsername={this.props.setUsername}
+          authenticating={authenticating}
+          connecting={connecting}
+          connected={connected}
           onToggleModalVisibility={this.onToggleModalVisibility} />}
 
         <main className="encloser">
@@ -136,6 +147,9 @@ const mapStateToProps = (reduxState) => {
     previousUsername: reduxState.chat.previousUsername,
     pincodeRequired: reduxState.chat.pincodeRequired,
     shouldConnect: reduxState.chat.shouldConnect,
+    connecting: reduxState.chat.connecting,
+    connected: reduxState.chat.connected,
+    authenticating: reduxState.chat.authenticating,
   };
 };
 

--- a/test/playwright/SetUsername.spec.js
+++ b/test/playwright/SetUsername.spec.js
@@ -10,6 +10,9 @@ test.beforeEach(async ({ page }) => {
 
 test.describe('Sets an initial user name', () => {
   test('sets username', async ({ page }) => {
+    await expect(page.locator(".form-group .alert-success")).toBeVisible();
+    await expect(page.locator(".form-group .alert-success")).toHaveText(/New room created/);
+
     await page.locator("#username").fill(username);
     await page.getByTestId("set-username").click();
 
@@ -19,25 +22,25 @@ test.describe('Sets an initial user name', () => {
   });
 
   test("sees an error if username is empty", async ({ page }) => {
-    await expect(page.getByRole("alert")).not.toBeVisible();
+    await expect(page.locator(".alert-danger")).not.toBeVisible();
     
     await page.locator("#username").fill("");
     await page.getByTestId("set-username").click();
     
-    await expect(page.getByRole("alert")).toBeVisible();
-    await expect(page.getByRole("alert")).toHaveText(/Must not be empty/);
+    await expect(page.locator(".form-group .alert-danger")).toBeVisible();
+    await expect(page.locator(".form-group .alert-danger")).toHaveText(/Must not be empty/);
   });
 
   test("sees an error if username is too long", async ({ page }) => {
-    await expect(page.getByRole("alert")).not.toBeVisible();
+    await expect(page.locator(".alert-danger")).not.toBeVisible();
 
     const tooLongUsername = new Array(MAX_USERNAME_LENGTH + 3).join("X");
     
     await page.locator("#username").fill(tooLongUsername);
     await page.getByTestId("set-username").click();
     
-    await expect(page.getByRole("alert")).toBeVisible();
+    await expect(page.locator(".alert-danger")).toBeVisible();
     const expectedError = new RegExp(`Length must not exceed ${MAX_USERNAME_LENGTH}`);
-    await expect(page.getByRole("alert")).toHaveText(expectedError);
+    await expect(page.locator(".alert-danger")).toHaveText(expectedError);
   });
 });


### PR DESCRIPTION

![welcome-message](https://user-images.githubusercontent.com/89764/221628908-08880df7-acf5-40a8-8d40-8b6da18f19b0.gif)


A simple welcome message and "connecting" indicator dialogue when the user first loads the page. Also renders an alert that indicates a new room was created or an existing one joined.

This is meant in part to address #200 

Also meant to address a slight usability issue, in that the username dialog form isn't responsive to user input until the connection has been established anyway. This would almost certainly be frustrating for quick-fingered users experiencing initial connection latency.