### PR TITLE
CSS: Change .form-control:focus glowing border color from blue to $funky-purple

### DIFF
--- a/src/static/sass/_layout.scss
+++ b/src/static/sass/_layout.scss
@@ -421,6 +421,11 @@ main {
   border-color: $funky-purple !important;
 }
 
+.form-control:focus {
+  box-shadow: 0 0 0 0.15rem #66339959;
+  border-color: $funky-purple !important;
+}
+
 // Allows textarea to be dynamic instead of static
 textarea {
   box-sizing: border-box !important;


### PR DESCRIPTION
The color looks a little weak compared to the blue that was there before, so we'll probably need to tweak this, but I think the general direction is probably good.