### PR TITLE
decouple chat action from the browser events api

### DIFF
--- a/src/components/chat/MessageForm.js
+++ b/src/components/chat/MessageForm.js
@@ -135,6 +135,11 @@ class MessageForm extends Component {
     }
   };
 
+  onMessageUpdate = (e) => {
+    const message = e.target.value;
+    this.props.messageUpdate(message);
+  };
+
   render() {
     const {
       message,
@@ -187,7 +192,7 @@ class MessageForm extends Component {
             <div className="message" onKeyDown={this.handleKeyDown}>
               <textarea
                 className="form-control"
-                onChange={this.props.messageUpdate}
+                onChange={this.onMessageUpdate}
                 onKeyPress={this.onKeyPress}
                 onKeyDown={this.onKeyDown}
                 name="message"

--- a/src/store/actions/chatActions.js
+++ b/src/store/actions/chatActions.js
@@ -52,8 +52,8 @@ export const setUsername = (username) =>
 export const usernameSet = (username) =>
   ({ type: CHAT_USERNAME_SET, username });
 
-export const messageUpdate = (e) =>
-  ({ type: 'CHAT_MESSAGE_UPDATE', message: e.target.value });
+export const messageUpdate = (message) =>
+  ({ type: 'CHAT_MESSAGE_UPDATE', message: message });
 
 export const clearMessage = () =>
   ({ type: 'CHAT_MESSAGE_CLEAR' });


### PR DESCRIPTION
Small change extracted from https://github.com/cryptag/leapchat/pull/298

Redux actions shouldn't know about the browser event API.