### PR TITLE
Restore original init connection flow epic; inject browser dependencies into chat epics

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -2,12 +2,9 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import {
   setUsername,
-  initAuth,
   initConnection,
   initChat
 } from '../store/actions/chatActions';
-
-import { initiateSessionAndConnect } from '../utils/sessions';
 
 import Header from './layout/Header';
 
@@ -59,21 +56,13 @@ class App extends Component {
     this.onInitConnection(pincode);
   };
 
-
-  onInitConnection(pincode='') {
-    // this.props.initAuth();
-
-    // const urlHash = document.location.hash + pincode;
-    // initiateSessionAndConnect(
-    //   this.props.initConnection,
-    //   this.createWebSession,
-    //   urlHash,
-    // );
-    this.props.initConnection(pincode);
+  createDeviceSession(passphrase) {
+    document.location.hash = '#' + passphrase;
   }
 
-  createWebSession(passphrase) {
-    document.location.hash = "#" + passphrase;
+  onInitConnection(pincode='') {
+    const urlHash = document.location.hash + pincode;
+    this.props.initConnection(this.createDeviceSession, urlHash);
   }
 
   onToggleModalVisibility = (modalName, isVisible) => {
@@ -122,7 +111,6 @@ class App extends Component {
           isVisible={showUsernameModal}
           isNewRoom={isNewRoom}
           setUsername={this.props.setUsername}
-          authenticating={authenticating}
           connecting={connecting}
           connected={connected}
           onToggleModalVisibility={this.onToggleModalVisibility} />}
@@ -150,26 +138,13 @@ const mapStateToProps = (reduxState) => {
     shouldConnect: reduxState.chat.shouldConnect,
     connecting: reduxState.chat.connecting,
     connected: reduxState.chat.connected,
-    authenticating: reduxState.chat.authenticating,
   };
 };
 
 const mapDispatchToProps = (dispatch) => {
   return {
     initChat: () => dispatch(initChat()),
-    initAuth: () => dispatch(initAuth()),
-    initConnection: (pincode) => dispatch(initConnection(pincode)),
-    // initConnection: ({
-    //   authToken,
-    //   secretKey,
-    //   mID,
-    //   isNewRoom
-    // }) => dispatch(initConnection({
-    //   authToken,
-    //   secretKey,
-    //   mID,
-    //   isNewRoom
-    // })),
+    initConnection: (createDeviceSession, urlHash) => dispatch(initConnection(createDeviceSession, urlHash)),
     setUsername: (username) => dispatch(setUsername(username)),
   };
 };

--- a/src/components/modals/Username.js
+++ b/src/components/modals/Username.js
@@ -18,7 +18,6 @@ const UsernameModal = ({
   onToggleModalVisibility,
   setUsername,
   enableAudio,
-  authenticating,
   connecting,
   connected,
 }) => {
@@ -75,11 +74,8 @@ const UsernameModal = ({
     <p>Cranking a bunch of gears.</p>
   );
 
-  if (authenticating) {
-    progress = 60;
-    statusMessage = <p>Establishing a session in your browser.</p>;
-  } else if (connecting) {
-    progress = 80;
+  if (connecting) {
+    progress = 50;
     statusMessage = <p>Creating a secure connection with LeapChat servers.</p>;
   } else if (connected) {
     progress = 95;
@@ -144,7 +140,6 @@ UsernameModal.propTypes = {
   username: PropTypes.string.isRequired,
   onToggleModalVisibility: PropTypes.func.isRequired,
   setUsername: PropTypes.func.isRequired,
-  authenticating: PropTypes.bool.isRequired,
   connecting: PropTypes.bool.isRequired,
   connected: PropTypes.bool.isRequired,
 };

--- a/src/store/actions/chatActions.js
+++ b/src/store/actions/chatActions.js
@@ -1,6 +1,5 @@
 
 export const CHAT_INIT_CHAT = 'CHAT_INIT_CHAT';
-export const CHAT_INIT_AUTH = 'CHAT_INIT_AUTH';
 export const CHAT_INIT_CONNECTION = 'CHAT_INIT_CONNECTION';
 export const CHAT_DISCONNECTED = 'CHAT_DISCONNECTED';
 export const CHAT_CONNECTION_INITIATED = 'CHAT_CONNECTION_INITIATED';
@@ -14,19 +13,8 @@ export const CHAT_USERNAME_SET = 'CHAT_USERNAME_SET';
 
 export const initChat = () => ({ type: CHAT_INIT_CHAT });
 
-export const initConnection = (pincode = '') =>
-  ({ type: CHAT_INIT_CONNECTION, pincode });
-
-export const initConnectionNew = ({
-  authToken, secretKey, mID, isNewRoom
-}) =>
-  ({
-    type: CHAT_INIT_CONNECTION,
-    authToken, secretKey, mID, isNewRoom
-  });
-
-export const initAuth = () =>
-  ({ type: CHAT_INIT_AUTH });
+export const initConnection = (createDeviceSession, urlHash ) =>
+  ({ type: CHAT_INIT_CONNECTION, createDeviceSession, urlHash });
 
 export const disconnected = () =>
   ({ type: CHAT_DISCONNECTED });

--- a/src/store/epics/helpers/createDetectPageVisibilityObservable.js
+++ b/src/store/epics/helpers/createDetectPageVisibilityObservable.js
@@ -6,6 +6,14 @@ import 'rxjs/add/observable/of';
 
 export default function createDetectPageVisibilityObservable() {
 
+  if (typeof document === "undefined") {
+    // make non-web versions a no-op for now
+    return new Observable((subscriber) => {
+      subscriber.next();
+      subscriber.complete();
+    });
+  }
+
   let hiddenKeyName, visibilityChangeEventName;
   if (typeof document.hidden !== "undefined") { // Opera 12.10 and Firefox 18 and later support
     hiddenKeyName = "hidden";

--- a/src/store/epics/helpers/urls.js
+++ b/src/store/epics/helpers/urls.js
@@ -1,0 +1,14 @@
+
+let hostname;
+if (typeof window.location !== "undefined") {
+  hostname = window.location.origin;
+} else {
+  // hard-coded for mobile device scenarios
+  hostname = "http://locahost:8080";
+}
+
+export const authUrl = `${hostname}/api/login`;
+
+const wsHostname = hostname.replace('http', 'ws');
+
+export const wsUrl = `${wsHostname}/api/ws/messages/all`;

--- a/src/store/reducers/chatReducer.js
+++ b/src/store/reducers/chatReducer.js
@@ -1,5 +1,4 @@
 import {
-  CHAT_INIT_AUTH,
   CHAT_INIT_CONNECTION,
   CHAT_CONNECTION_INITIATED,
   CHAT_DISCONNECTED,
@@ -8,17 +7,19 @@ import {
   CHAT_USERNAME_SET
 } from '../actions/chatActions';
 
-import {
-  PARANOID_USERNAME,
-  USERNAME_KEY
-} from '../../constants/messaging';
+import { PARANOID_USERNAME } from '../../constants/messaging';
 
-const paranoidMode = document && document.location.hash.endsWith('----') || false;
-const pincodeRequired = document && document.location.hash.endsWith('--') || false;
-const previousUsername = localStorage && localStorage.getItem(USERNAME_KEY) || '';
+import {
+  getPersistedUsername,
+  getIsParanoidMode,
+  getIsPincodeRequired
+} from './helpers/deviceState';
+
+const paranoidMode = getIsParanoidMode();
+const pincodeRequired = getIsPincodeRequired();
+const previousUsername = getPersistedUsername();
 
 const initialState = {
-  authenticating: false,
   connecting: false,
   connected: false,
   shouldConnect: true,
@@ -42,21 +43,9 @@ function chatReducer(state = initialState, action) {
 
   switch (action.type) {
 
-  case CHAT_INIT_AUTH:
-    return Object.assign({}, state, {
-      messages: [],
-      authenticating: true,
-      connecting: false,
-      connected: false,
-      shouldConnect: false,
-      pincodeRequired: false,
-      ready: false
-    });
-
   case CHAT_INIT_CONNECTION:
     return Object.assign({}, state, {
       messages: [],
-      authenticating: false,
       connecting: true,
       connected: false,
       shouldConnect: false,
@@ -66,7 +55,6 @@ function chatReducer(state = initialState, action) {
 
   case CHAT_CONNECTION_INITIATED:
     return Object.assign({}, state, {
-      authenticating: false,
       connecting: false,
       connected: true,
       shouldConnect: false,

--- a/src/store/reducers/helpers/deviceState.js
+++ b/src/store/reducers/helpers/deviceState.js
@@ -1,0 +1,29 @@
+import { USERNAME_KEY } from "../../../constants/messaging";
+
+
+export const persistUsername = (username) => {
+  if (typeof localStorage !== "undefined"){
+    localStorage.setItem(USERNAME_KEY, username);
+  }
+};
+
+export const getPersistedUsername = () => {
+  if (typeof localStorage !== "undefined"){
+    return localStorage.getItem(USERNAME_KEY);
+  }
+  return '';
+};
+
+export const getIsParanoidMode = () => {
+  if (typeof document !== "undefined"){
+    return document.location.hash.endsWith('----') || false;
+  }
+  return false;
+};
+
+export const getIsPincodeRequired = () => {
+  if (typeof document !== "undefined") {
+    return  document.location.hash.endsWith('--') || false;
+  }
+  return false;
+};

--- a/src/utils/sessions.js
+++ b/src/utils/sessions.js
@@ -1,3 +1,13 @@
+
+/**
+ * Module intended to replace the init connection epic in chatEpics.js
+ * Currently lacking connection retry capabilities on disconnect.
+ * STRs: create a chat session in the browser, then kill the running 
+ *    leapchat binary, to simulate the server going away.
+ * The 'disconnected' action can be dispatched on connection error,
+ * however, this doesn't initiate a proper re-connect flow.
+ * UNUSED FOR NOW.
+ */
 import { getEmail, getPassphrase } from '../utils/encrypter';
 import miniLock from '../utils/miniLock';
 


### PR DESCRIPTION
This cleans up the reworking of the init connect epic to be not be an epic. The objective there was to eliminate the direct dependency on the device from the epics themselves. This is much more easily done, with minimal potential unintended loss of functionality, via the means in this PR.